### PR TITLE
always use all labels for Cypher.node

### DIFF
--- a/src/main/kotlin/io/github/graphglue/authorization/AuthorizationChecker.kt
+++ b/src/main/kotlin/io/github/graphglue/authorization/AuthorizationChecker.kt
@@ -26,7 +26,7 @@ class AuthorizationChecker(
     fun hasAuthorization(node: Node, permission: Permission): Mono<Boolean> {
         val nodeDefinition = collection.getNodeDefinition(node::class)
         val conditionGenerator = collection.generateAuthorizationCondition(nodeDefinition, permission)
-        val cypherNode = Cypher.node(nodeDefinition.primaryLabel).withProperties(mapOf("id" to node.rawId!!))
+        val cypherNode = nodeDefinition.node().withProperties(mapOf("id" to node.rawId!!))
         val condition = conditionGenerator.generateCondition(cypherNode)
         val statement = Cypher.match(cypherNode).returning(condition).build()
         val queryResult = client.query(Renderer.getDefaultRenderer().render(statement)).bindAll(statement.parameters)

--- a/src/main/kotlin/io/github/graphglue/data/execution/NodeQueryExecutor.kt
+++ b/src/main/kotlin/io/github/graphglue/data/execution/NodeQueryExecutor.kt
@@ -69,7 +69,7 @@ class NodeQueryExecutor(
      * @return the generated query and result column name
      */
     private fun createRootNodeQuery(): StatementWithSymbolicName {
-        val rootNode = createNodeDefinitionNode(nodeQuery.definition).named(generateUniqueName().value)
+        val rootNode = nodeQuery.definition.node().named(generateUniqueName().value)
         val builder = Cypher.match(rootNode).with(rootNode)
         return createNodeQuery(nodeQuery, builder, rootNode)
     }
@@ -370,7 +370,7 @@ class NodeQueryExecutor(
             labelCondition = labelCondition.or(node.hasLabels(nodeDefinition.primaryLabel))
         }
         val nodeQuery = subQuery.query
-        val relatedNode = createNodeDefinitionNode(nodeQuery.definition).named(generateUniqueName().value)
+        val relatedNode = nodeQuery.definition.node().named(generateUniqueName().value)
 
         val builder = Cypher.with(node)
             .with(node)
@@ -384,16 +384,6 @@ class NodeQueryExecutor(
      * Generates a new unique name
      */
     private fun generateUniqueName() = Cypher.name("a_${nameCounter++}")
-
-    /**
-     * Creates a [Node] for a [NodeDefinition].
-     *
-     * @param nodeDefinition the definition for which to create the [Node]
-     * @return the generated [Node] with the correct primaryLabel
-     */
-    private fun createNodeDefinitionNode(nodeDefinition: NodeDefinition): Node {
-        return Cypher.node(nodeDefinition.primaryLabel)
-    }
 
     /**
      * Parses the result of a query (a list of nodes, and optional a totalCount).

--- a/src/main/kotlin/io/github/graphglue/data/execution/NodeQueryParser.kt
+++ b/src/main/kotlin/io/github/graphglue/data/execution/NodeQueryParser.kt
@@ -47,13 +47,14 @@ class NodeQueryParser(
      */
     fun generateRelationshipNodeQuery(
         definition: NodeDefinition,
+        parentDefinition: NodeDefinition,
         dataFetchingEnvironment: DataFetchingEnvironment?,
         relationshipDefinition: RelationshipDefinition,
         parentNode: Node,
         requiredPermission: Permission?
     ): NodeQuery {
         val idParameter = Cypher.anonParameter(parentNode.rawId)
-        val rootCypherNode = Cypher.anyNode().withProperties(mapOf("id" to idParameter))
+        val rootCypherNode = parentDefinition.node().withProperties(mapOf("id" to idParameter))
         val additionalConditions = listOf(CypherConditionGenerator { node ->
             Predicates.any(rootCypherNode.requiredSymbolicName).`in`(
                 Cypher.listBasedOn(relationshipDefinition.generateRelationship(rootCypherNode, node))

--- a/src/main/kotlin/io/github/graphglue/definition/NodeDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/definition/NodeDefinition.kt
@@ -6,6 +6,7 @@ import io.github.graphglue.graphql.extensions.getSimpleName
 import io.github.graphglue.graphql.extensions.springFindRepeatableAnnotations
 import io.github.graphglue.model.Authorization
 import io.github.graphglue.model.Node
+import org.neo4j.cypherdsl.core.Cypher
 import org.neo4j.cypherdsl.core.Expression
 import org.neo4j.cypherdsl.core.SymbolicName
 import org.springframework.data.neo4j.core.mapping.Constants
@@ -126,6 +127,13 @@ class NodeDefinition(
      */
     fun getRelationshipDefinitionOfProperty(property: KProperty1<*, *>): RelationshipDefinition {
         return relationshipDefinitionsByProperty[property.name]!!
+    }
+
+    /**
+     * Generates a new CypherDSL node with the necessary labels
+     */
+    fun node(): org.neo4j.cypherdsl.core.Node {
+        return Cypher.node(persistentEntity.primaryLabel, persistentEntity.additionalLabels)
     }
 
     override fun toString() = nodeType.getSimpleName()

--- a/src/main/kotlin/io/github/graphglue/definition/NodeDefinitionCollection.kt
+++ b/src/main/kotlin/io/github/graphglue/definition/NodeDefinitionCollection.kt
@@ -349,7 +349,7 @@ class NodeDefinitionCollection(
         val allowFromRelatedCondition = authorization.allowFromRelated
             .fold(Conditions.noCondition()) { condition, relationshipDefinition ->
                 val relatedNodeDefinition = getNodeDefinition(relationshipDefinition.nodeKClass)
-                val relatedNode = Cypher.node(relatedNodeDefinition.primaryLabel)
+                val relatedNode =relatedNodeDefinition.node()
                 val newPattern = relationshipDefinition.generateRelationship(node, relatedNode)
                 val newPart = generateAuthorizationConditionInternal(
                     relatedNode, newPattern, relatedNodeDefinition, permission, false
@@ -384,7 +384,7 @@ class NodeDefinitionCollection(
     ): AuthorizationConditionPart {
         val relationshipDefinition = authorization.allowFromRelated.first()
         val relatedNodeDefinition = getNodeDefinition(relationshipDefinition.nodeKClass)
-        val relatedNode = Cypher.node(relatedNodeDefinition.primaryLabel)
+        val relatedNode = relatedNodeDefinition.node()
         val newPattern = relationshipDefinition.generateRelationship(pattern, relatedNode)
         val newPart = generateAuthorizationConditionInternal(
             relatedNode, newPattern, relatedNodeDefinition, permission, false

--- a/src/main/kotlin/io/github/graphglue/definition/NodeDefinitionCollection.kt
+++ b/src/main/kotlin/io/github/graphglue/definition/NodeDefinitionCollection.kt
@@ -349,7 +349,7 @@ class NodeDefinitionCollection(
         val allowFromRelatedCondition = authorization.allowFromRelated
             .fold(Conditions.noCondition()) { condition, relationshipDefinition ->
                 val relatedNodeDefinition = getNodeDefinition(relationshipDefinition.nodeKClass)
-                val relatedNode =relatedNodeDefinition.node()
+                val relatedNode = relatedNodeDefinition.node()
                 val newPattern = relationshipDefinition.generateRelationship(node, relatedNode)
                 val newPart = generateAuthorizationConditionInternal(
                     relatedNode, newPattern, relatedNodeDefinition, permission, false

--- a/src/main/kotlin/io/github/graphglue/definition/RelationshipDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/definition/RelationshipDefinition.kt
@@ -135,10 +135,15 @@ abstract class RelationshipDefinition(
      *
      * @param node the node which contains the property to get the diff from
      * @param nodeIdLookup node to id lookup, can be used to get id of unpersisted nodes
+     * @param nodeDefinition definition of the related nodes
      * @return the diff describing added and removed nodes
      */
-    internal fun getRelationshipDiff(node: Node, nodeIdLookup: Map<Node, String>): RelationshipDiff {
-        return node.getProperty<Node>(property).getRelationshipDiff(nodeIdLookup)
+    internal fun getRelationshipDiff(
+        node: Node,
+        nodeIdLookup: Map<Node, String>,
+        nodeDefinition: NodeDefinition
+    ): RelationshipDiff {
+        return node.getProperty<Node>(property).getRelationshipDiff(nodeIdLookup, nodeDefinition)
     }
 
     /**

--- a/src/main/kotlin/io/github/graphglue/model/BaseProperty.kt
+++ b/src/main/kotlin/io/github/graphglue/model/BaseProperty.kt
@@ -7,6 +7,7 @@ import graphql.schema.DataFetchingEnvironment
 import io.github.graphglue.data.execution.*
 import io.github.graphglue.definition.NodeDefinitionCollection
 import io.github.graphglue.data.repositories.RelationshipDiff
+import io.github.graphglue.definition.NodeDefinition
 import io.github.graphglue.graphql.extensions.getParentNodeDefinition
 import org.springframework.beans.factory.annotation.Autowired
 import java.util.*
@@ -90,9 +91,13 @@ abstract class BaseProperty<T : Node?>(protected val parent: Node, protected val
      *
      * @param nodeIdLookup lookup from [Node] to its id to add relation to non-persisted nodes
      *                     (these nodes are already persisted, but not newly fetched from the database)
+     * @param nodeDefinition the definition of the nodes in this property, can be used to get the Label(s) of the node(s)
      * @return the diff which describes how to add and remove relationships
      */
-    internal abstract fun getRelationshipDiff(nodeIdLookup: Map<Node, String>): RelationshipDiff
+    internal abstract fun getRelationshipDiff(
+        nodeIdLookup: Map<Node, String>,
+        nodeDefinition: NodeDefinition
+    ): RelationshipDiff
 
     /**
      * Gets [Node]s which should be persisted when this [Node] is persisted

--- a/src/main/kotlin/io/github/graphglue/model/Node.kt
+++ b/src/main/kotlin/io/github/graphglue/model/Node.kt
@@ -131,6 +131,7 @@ abstract class Node {
             )
             val query = queryParser.generateRelationshipNodeQuery(
                 nodeDefinition,
+                parentNodeDefinition,
                 dataFetchingEnvironment,
                 relationshipDefinition,
                 this,

--- a/src/main/kotlin/io/github/graphglue/model/NodeProperty.kt
+++ b/src/main/kotlin/io/github/graphglue/model/NodeProperty.kt
@@ -3,6 +3,7 @@ package io.github.graphglue.model
 import graphql.execution.DataFetcherResult
 import io.github.graphglue.data.execution.*
 import io.github.graphglue.data.repositories.RelationshipDiff
+import io.github.graphglue.definition.NodeDefinition
 import kotlinx.coroutines.runBlocking
 import org.neo4j.cypherdsl.core.Cypher
 import kotlin.reflect.KProperty
@@ -92,7 +93,10 @@ class NodeProperty<T : Node?>(
         }
     }
 
-    override fun getRelationshipDiff(nodeIdLookup: Map<Node, String>): RelationshipDiff {
+    override fun getRelationshipDiff(
+        nodeIdLookup: Map<Node, String>,
+        nodeDefinition: NodeDefinition
+    ): RelationshipDiff {
         val current = currentNode
         val nodesToRemove = if (current != persistedNode) {
             listOf(Cypher.anyNode())
@@ -101,7 +105,7 @@ class NodeProperty<T : Node?>(
         }
         val nodesToAdd = if (current != persistedNode && current != null) {
             val idParameter = Cypher.anonParameter(nodeIdLookup[current])
-            listOf(Cypher.anyNode().withProperties(mapOf("id" to idParameter)))
+            listOf(nodeDefinition.node().withProperties(mapOf("id" to idParameter)))
         } else {
             emptyList()
         }

--- a/src/main/kotlin/io/github/graphglue/model/NodeSetProperty.kt
+++ b/src/main/kotlin/io/github/graphglue/model/NodeSetProperty.kt
@@ -5,6 +5,7 @@ import io.github.graphglue.data.execution.NodeQuery
 import io.github.graphglue.data.execution.NodeQueryParser
 import io.github.graphglue.data.execution.NodeQueryResult
 import io.github.graphglue.data.repositories.RelationshipDiff
+import io.github.graphglue.definition.NodeDefinition
 import kotlinx.coroutines.runBlocking
 import org.neo4j.cypherdsl.core.Cypher
 import java.util.*
@@ -75,15 +76,18 @@ class NodeSetProperty<T : Node>(
             .build()
     }
 
-    override fun getRelationshipDiff(nodeIdLookup: Map<Node, String>): RelationshipDiff {
+    override fun getRelationshipDiff(
+        nodeIdLookup: Map<Node, String>,
+        nodeDefinition: NodeDefinition
+    ): RelationshipDiff {
         return RelationshipDiff(
             addedNodes.map {
                 val idParameter = Cypher.anonParameter(nodeIdLookup[it])
-                Cypher.anyNode().withProperties(mapOf("id" to idParameter))
+                nodeDefinition.node().withProperties(mapOf("id" to idParameter))
             },
             removedNodes.filter { it.rawId != null }.map {
                 val idParameter = Cypher.anonParameter(it.rawId!!)
-                Cypher.anyNode().withProperties(mapOf("id" to idParameter))
+                nodeDefinition.node().withProperties(mapOf("id" to idParameter))
             }
         )
     }


### PR DESCRIPTION
Replaces some instances of `Cypher.node(primaryLabel)` and `Cypher.anyNode()`  
Those do not use all labels, and therefore do not profit from potentially existing indices and unique constraints.  
To fix this, a new function on `NodeDefinition` was introduced, which creates the CypherDSL `Node` with the correct labels.  
This improves the performance (if indices are present) significantly.