### PR TITLE
mark input of Node.NodeProperty as nullable

### DIFF
--- a/src/main/kotlin/io/github/graphglue/model/Node.kt
+++ b/src/main/kotlin/io/github/graphglue/model/Node.kt
@@ -103,7 +103,7 @@ abstract class Node {
      * @param T value type
      * @return a provider for the property delegate
      */
-    protected fun <T : Node> NodeProperty(): PropertyDelegateProvider<Node, NodeProperty<T>> {
+    protected fun <T : Node?> NodeProperty(): PropertyDelegateProvider<Node, NodeProperty<T>> {
         return NodePropertyProvider()
     }
 


### PR DESCRIPTION
- allow input type of Node.NodeProperty to be nullable. This bug was introduced during a refactoring of the property generation functions