### PR TITLE
upgrade GraphQL Kotlin to 6.0.0-alpha.2 to get grapql-java 18.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ description = "A library to develop annotation-based code-first GraphQL servers 
 version = "1.2.1-SNAPSHOT"
 group = "io.github.graphglue"
 
-val graphqlKotlinVersion = "5.3.2"
+val graphqlKotlinVersion = "6.0.0-alpha.2"
 val springBootVersion = "2.6.7"
 
 plugins {


### PR DESCRIPTION
We need to upgrade to graphql-java 18.0, as we use `GraphQLTypeReference` when adding interfaces to types during schema transformation, and are impacted by [github.com/graphql-java/graphql-java/issues/2546](https://togithub.com/graphql-java/graphql-java/issues/2546). This makes it necessary to upgrade to GraphQL Kotlin 6.0.0-alpha.2