### PR TITLE
fix nullable order fields

### DIFF
--- a/src/main/kotlin/io/github/graphglue/connection/order/OrderPart.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/order/OrderPart.kt
@@ -9,8 +9,9 @@ import io.github.graphglue.model.Node
  * @param T the type of [Node] for which the order is defined
  * @param name name of the field in the cursor JSON
  * @param neo4jPropertyName name of the property on the database node
+ * @param isNullable if true, this part can be null
  */
-abstract class OrderPart<in T : Node>(val name: String, val neo4jPropertyName: String) {
+abstract class OrderPart<in T : Node>(val name: String, val neo4jPropertyName: String, val isNullable: Boolean) {
     /**
      * Gets the value of the field of a [Node]
      *

--- a/src/main/kotlin/io/github/graphglue/connection/order/SimpleOrderPart.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/order/SimpleOrderPart.kt
@@ -9,8 +9,9 @@ import kotlin.reflect.KProperty
  * @param property defines the part, provides a name and used for [getValue]
  * @param neo4jPropertyName name of the property on the database node
  */
-class SimpleOrderPart<T : Node>(private val property: KProperty<*>, neo4jPropertyName: String) :
-    OrderPart<T>(property.name, neo4jPropertyName) {
+class SimpleOrderPart<T : Node>(
+    private val property: KProperty<*>, neo4jPropertyName: String
+) : OrderPart<T>(property.name, neo4jPropertyName, property.returnType.isMarkedNullable) {
     override fun getValue(node: T): Any? {
         return property.getter.call(node)
     }


### PR DESCRIPTION
In Cypher, both `5 < null` and `5 > null` result in `null` which is coerced to `false`.  
Therefore, nullable OrderFields need additional logic so that the correct order is generated, and no Nodes are excluded from the pagination.