### PR TITLE
simplify filter structure

### DIFF
--- a/src/main/kotlin/io/github/graphglue/connection/filter/model/Filter.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/model/Filter.kt
@@ -6,8 +6,8 @@ import org.neo4j.cypherdsl.core.Node
 /**
  * Parsed version of an overall filter
  *
- * @param metaFilter the top level parsed filter
+ * @param nodeFilter the top level parsed filter
  */
-data class Filter(val metaFilter: MetaFilter) : CypherConditionGenerator {
-    override fun generateCondition(node: Node) = metaFilter.generateCondition(node)
+data class Filter(val nodeFilter: NodeFilter) : CypherConditionGenerator {
+    override fun generateCondition(node: Node) = nodeFilter.generateCondition(node)
 }

--- a/src/main/kotlin/io/github/graphglue/connection/filter/model/MetaFilter.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/model/MetaFilter.kt
@@ -11,61 +11,50 @@ import org.neo4j.cypherdsl.core.Node
 abstract class MetaFilter : CypherConditionGenerator
 
 /**
- * [MetaFilter] which joins several [MetaFilter]s by AND
+ * [MetaFilter] which joins several [NodeFilter]s by AND
  *
- * @param subMetaFilters the list of filters to join
+ * @param subNodeFilters the list of filters to join
  */
-data class AndMetaFilter(val subMetaFilters: List<MetaFilter>) : MetaFilter() {
+data class AndMetaFilter(val subNodeFilters: List<NodeFilter>) : MetaFilter() {
     init {
-        if (subMetaFilters.isEmpty()) {
+        if (subNodeFilters.isEmpty()) {
             throw IllegalArgumentException("no sub-filters provided")
         }
     }
 
     override fun generateCondition(node: Node): Condition {
-        return subMetaFilters.fold(Conditions.noCondition()) { condition, subMetaFilter ->
-            condition.and(subMetaFilter.generateCondition(node))
+        return subNodeFilters.fold(Conditions.noCondition()) { condition, subNodeFilter ->
+            condition.and(subNodeFilter.generateCondition(node))
         }
     }
 }
 
 /**
- * [MetaFilter] which joins several [MetaFilter]s by OR
+ * [MetaFilter] which joins several [NodeFilter]s by OR
  *
- * @param subMetaFilters the list of filters to join
+ * @param subNodeFilters the list of filters to join
  */
-data class OrMetaFilter(val subMetaFilters: List<MetaFilter>) : MetaFilter() {
+data class OrMetaFilter(val subNodeFilters: List<NodeFilter>) : MetaFilter() {
     init {
-        if (subMetaFilters.isEmpty()) {
+        if (subNodeFilters.isEmpty()) {
             throw IllegalArgumentException("no sub-filters provided")
         }
     }
 
     override fun generateCondition(node: Node): Condition {
-        return subMetaFilters.fold(Conditions.noCondition()) { condition, subMetaFilter ->
-            condition.or(subMetaFilter.generateCondition(node))
+        return subNodeFilters.fold(Conditions.noCondition()) { condition, subNodeFilter ->
+            condition.or(subNodeFilter.generateCondition(node))
         }
     }
 }
 
 /**
- * [MetaFilter] which negates a single [MetaFilter]
+ * [MetaFilter] which negates a single [NodeFilter]
  *
- * @param subMetaFilter the filter to negate
+ * @param subNodeFilter the filter to negate
  */
-data class NotMetaFilter(val subMetaFilter: MetaFilter) : MetaFilter() {
+data class NotMetaFilter(val subNodeFilter: NodeFilter) : MetaFilter() {
     override fun generateCondition(node: Node): Condition {
-        return subMetaFilter.generateCondition(node).not()
-    }
-}
-
-/**
- * [MetaFilter] to wrap a [NodeFilter]
- *
- * @param nodeFilter the filter to wrap
- */
-data class NodeMetaFilter(val nodeFilter: NodeFilter) : MetaFilter() {
-    override fun generateCondition(node: Node): Condition {
-        return nodeFilter.generateCondition(node)
+        return subNodeFilter.generateCondition(node).not()
     }
 }

--- a/src/main/kotlin/io/github/graphglue/connection/filter/model/NodeFilter.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/model/NodeFilter.kt
@@ -11,7 +11,7 @@ import org.neo4j.cypherdsl.core.Node
  *
  * @param entries the entries to join
  */
-data class NodeFilter(val entries: List<FilterEntry> = emptyList()) : CypherConditionGenerator {
+data class NodeFilter(val entries: List<CypherConditionGenerator> = emptyList()) : CypherConditionGenerator {
     override fun generateCondition(node: Node): Condition {
         return if (entries.isEmpty()) {
             Conditions.isTrue()


### PR DESCRIPTION
This changes the way meta filters can be constructed.  
Currently, when filtering for nodes, there is a strict separation between the filters directly applied on the node and meta filters. Meta filters join other meta filters by **and**, **or** and **not**, or consist of just a single node filter.  
This PR removes this strict separation, and makes the meta filter fields just normal fields on the node filter itself, which are joined by and. 
Previously, the strict separation was chosen to separate clearly between the two levels of abstraction, at the cost of much more complex filter inputs. However, simplifying makes writing filters much easier, while keeping all provided functionality, simplifying user interaction with the api.  Additionaly, this is also the common way other technologies (like DGraph) implement this feature.

Consider the following example of filtering where name starts with "a" and not ends with "b"  

Currently, such a filter looks like this:
```gql
{
    and: [
        {
            node: {
                startsWith: "a"
            }
        },
        {
            not: {
                node: {
                    name: {
                        endsWith: "b"
                    }
                }
            }
        }
    ]
}
```
With the proposed changes, it can be as simple as this:
```gql
{
    name: {
        startsWith: "a"
    },
    not: {
        name: {
            endsWith: "b"
        }
    }
}
```
Of course, it is still possible to declare an identical filter with a clearer separation between meta filter and node filter (as this can be helpful for tools):
```gql
{
    and: [
        {
            startsWith: "a"
        },
        {
            not: {
                name: {
                    endsWith: "b"
                }
            }
        }
    ]
}
```

As this is a breaking change, if this PR gets accepted, the next released version will be 2.0.0