### PR TITLE
Feature/improved relation filters

### DIFF
--- a/src/main/kotlin/io/github/graphglue/connection/GraphglueConnectionConfiguration.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/GraphglueConnectionConfiguration.kt
@@ -2,7 +2,8 @@ package io.github.graphglue.connection
 
 import com.expediagroup.graphql.generator.scalars.ID
 import io.github.graphglue.connection.filter.TypeFilterDefinitionEntry
-import io.github.graphglue.connection.filter.definition.NodeSetFilterDefinition
+import io.github.graphglue.connection.filter.definition.NodePropertyFilterDefinition
+import io.github.graphglue.connection.filter.definition.NodeSetPropertyFilterDefinition
 import io.github.graphglue.connection.filter.definition.NodeSubFilterDefinition
 import io.github.graphglue.connection.filter.definition.scalars.*
 import io.github.graphglue.model.Node
@@ -93,14 +94,15 @@ class GraphglueConnectionConfiguration {
      */
     @Bean
     fun nodeFilter() =
-        TypeFilterDefinitionEntry(Node::class.createType()) { name, property, parentNodeDefinition, subFilterGenerator ->
-            NodeSubFilterDefinition(
+        TypeFilterDefinitionEntry(Node::class.createType(nullable = true)) { name, property, parentNodeDefinition, subFilterGenerator ->
+            val nodeSubFilterDefinition = NodeSubFilterDefinition(
                 name,
                 "Filters for nodes where the related node match this filter",
                 property.returnType,
                 subFilterGenerator,
                 parentNodeDefinition.getRelationshipDefinitionOfProperty(property)
             )
+            NodePropertyFilterDefinition(nodeSubFilterDefinition)
         }
 
     /**
@@ -112,7 +114,7 @@ class GraphglueConnectionConfiguration {
     @Bean
     fun nodeSetFilter() =
         TypeFilterDefinitionEntry(Set::class.createType(listOf(KTypeProjection.covariant(Node::class.createType())))) { name, property, parentNodeDefinition, subFilterGenerator ->
-            NodeSetFilterDefinition(
+            NodeSetPropertyFilterDefinition(
                 name,
                 property.returnType.arguments.first().type!!,
                 subFilterGenerator,

--- a/src/main/kotlin/io/github/graphglue/connection/filter/definition/FilterEntryDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/definition/FilterEntryDefinition.kt
@@ -1,6 +1,7 @@
 package io.github.graphglue.connection.filter.definition
 
 import graphql.schema.GraphQLInputObjectType
+import io.github.graphglue.authorization.Permission
 import io.github.graphglue.connection.filter.model.FilterEntry
 
 /**
@@ -18,5 +19,5 @@ abstract class FilterEntryDefinition(val name: String, val description: String) 
      * @param value the value to parse
      * @return the parsed filter entry
      */
-    abstract fun parseEntry(value: Any?): FilterEntry
+    abstract fun parseEntry(value: Any?, permission: Permission?): FilterEntry
 }

--- a/src/main/kotlin/io/github/graphglue/connection/filter/definition/NodePropertyFilterDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/definition/NodePropertyFilterDefinition.kt
@@ -1,0 +1,24 @@
+package io.github.graphglue.connection.filter.definition
+
+import graphql.schema.GraphQLInputType
+import io.github.graphglue.connection.filter.model.AnyNodeRelationshipFilterEntry
+import io.github.graphglue.connection.filter.model.FilterEntry
+import io.github.graphglue.util.CacheMap
+
+/**
+ * Definition for a filter used to filter for NodeProperties
+ *
+ * @param nodeSubFilterDefinition the filter which is wrapped to filter for the relationship
+ */
+class NodePropertyFilterDefinition(
+    private val nodeSubFilterDefinition: NodeSubFilterDefinition
+) : FilterEntryDefinition(nodeSubFilterDefinition.name, nodeSubFilterDefinition.description) {
+
+    override fun parseEntry(value: Any?): FilterEntry {
+        return AnyNodeRelationshipFilterEntry(nodeSubFilterDefinition, nodeSubFilterDefinition.parseEntry(value))
+    }
+
+    override fun toGraphQLType(inputTypeCache: CacheMap<String, GraphQLInputType>): GraphQLInputType {
+        return nodeSubFilterDefinition.toGraphQLType(inputTypeCache)
+    }
+}

--- a/src/main/kotlin/io/github/graphglue/connection/filter/definition/NodePropertyFilterDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/definition/NodePropertyFilterDefinition.kt
@@ -1,6 +1,7 @@
 package io.github.graphglue.connection.filter.definition
 
 import graphql.schema.GraphQLInputType
+import io.github.graphglue.authorization.Permission
 import io.github.graphglue.connection.filter.model.AnyNodeRelationshipFilterEntry
 import io.github.graphglue.connection.filter.model.FilterEntry
 import io.github.graphglue.util.CacheMap
@@ -14,8 +15,10 @@ class NodePropertyFilterDefinition(
     private val nodeSubFilterDefinition: NodeSubFilterDefinition
 ) : FilterEntryDefinition(nodeSubFilterDefinition.name, nodeSubFilterDefinition.description) {
 
-    override fun parseEntry(value: Any?): FilterEntry {
-        return AnyNodeRelationshipFilterEntry(nodeSubFilterDefinition, nodeSubFilterDefinition.parseEntry(value))
+    override fun parseEntry(value: Any?, permission: Permission?): FilterEntry {
+        return AnyNodeRelationshipFilterEntry(
+            nodeSubFilterDefinition, nodeSubFilterDefinition.parseEntry(value, permission), permission
+        )
     }
 
     override fun toGraphQLType(inputTypeCache: CacheMap<String, GraphQLInputType>): GraphQLInputType {

--- a/src/main/kotlin/io/github/graphglue/connection/filter/definition/NodeSetPropertyFilterDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/definition/NodeSetPropertyFilterDefinition.kt
@@ -1,6 +1,7 @@
 package io.github.graphglue.connection.filter.definition
 
 import graphql.schema.GraphQLInputObjectType
+import io.github.graphglue.authorization.Permission
 import io.github.graphglue.connection.filter.model.*
 import io.github.graphglue.definition.RelationshipDefinition
 import io.github.graphglue.graphql.extensions.getSimpleName
@@ -50,16 +51,16 @@ class NodeSetPropertyFilterDefinition(
     )
 ) {
 
-    override fun parseEntry(value: Any?): FilterEntry {
+    override fun parseEntry(value: Any?, permission: Permission?): FilterEntry {
         value as Map<*, *>
         val entries = value.map {
             val (name, entry) = it
             val definition = fields[name] ?: throw IllegalStateException("Unknown input")
-            val filter = definition.parseEntry(entry)
+            val filter = definition.parseEntry(entry, permission)
             when (name) {
-                "all" -> AllNodeRelationshipFilterEntry(definition, filter)
-                "any" -> AnyNodeRelationshipFilterEntry(definition, filter)
-                "none" -> NoneNodeRelationshipFilterEntry(definition, filter)
+                "all" -> AllNodeRelationshipFilterEntry(definition, filter, permission)
+                "any" -> AnyNodeRelationshipFilterEntry(definition, filter, permission)
+                "none" -> NoneNodeRelationshipFilterEntry(definition, filter, permission)
                 else -> throw IllegalStateException("Unknown NodeListFilter entry")
             }
         }

--- a/src/main/kotlin/io/github/graphglue/connection/filter/definition/NodeSetPropertyFilterDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/definition/NodeSetPropertyFilterDefinition.kt
@@ -9,7 +9,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.jvm.jvmErasure
 
 /**
- * Definition for a set based filter
+ * Definition for a set based filter used to filter for NodeSetProperties
  * Can be used for filters where either all, any or none of the elements of the list have to
  * match a filter
  *
@@ -18,7 +18,7 @@ import kotlin.reflect.jvm.jvmErasure
  * @param subFilterGenerator used to generate the filter for the `nodeType`
  * @param relationshipDefinition defines the relationship the property defines
  */
-class NodeSetFilterDefinition(
+class NodeSetPropertyFilterDefinition(
     name: String,
     nodeType: KType,
     subFilterGenerator: SubFilterGenerator,
@@ -57,13 +57,13 @@ class NodeSetFilterDefinition(
             val definition = fields[name] ?: throw IllegalStateException("Unknown input")
             val filter = definition.parseEntry(entry)
             when (name) {
-                "all" -> AllNodeSetFilterEntry(definition, filter)
-                "any" -> AnyNodeSetFilterEntry(definition, filter)
-                "none" -> NoneNodeSetFilterEntry(definition, filter)
+                "all" -> AllNodeRelationshipFilterEntry(definition, filter)
+                "any" -> AnyNodeRelationshipFilterEntry(definition, filter)
+                "none" -> NoneNodeRelationshipFilterEntry(definition, filter)
                 else -> throw IllegalStateException("Unknown NodeListFilter entry")
             }
         }
-        return NodeSetFilter(this, entries)
+        return NodeSetPropertyFilter(this, entries)
     }
 }
 

--- a/src/main/kotlin/io/github/graphglue/connection/filter/definition/NodeSubFilterDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/definition/NodeSubFilterDefinition.kt
@@ -2,6 +2,7 @@ package io.github.graphglue.connection.filter.definition
 
 import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLInputType
+import io.github.graphglue.authorization.Permission
 import io.github.graphglue.connection.filter.model.NodeSubFilter
 import io.github.graphglue.definition.RelationshipDefinition
 import io.github.graphglue.model.Node
@@ -34,7 +35,8 @@ class NodeSubFilterDefinition(
     @Suppress("UNCHECKED_CAST")
     private val subFilter = generateFilterDefinition(nodeType.jvmErasure as KClass<out Node>, subFilterGenerator)
 
-    override fun parseEntry(value: Any?) = NodeSubFilter(this, subFilter.parseFilter(value))
+    override fun parseEntry(value: Any?, permission: Permission?) =
+        NodeSubFilter(this, subFilter.parseFilter(value, permission))
 
     override fun toGraphQLType(inputTypeCache: CacheMap<String, GraphQLInputType>) =
         subFilter.toGraphQLType(inputTypeCache)

--- a/src/main/kotlin/io/github/graphglue/connection/filter/definition/NodeSubFilterDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/definition/NodeSubFilterDefinition.kt
@@ -4,6 +4,7 @@ import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLInputType
 import io.github.graphglue.authorization.Permission
 import io.github.graphglue.connection.filter.model.NodeSubFilter
+import io.github.graphglue.data.execution.CypherConditionGenerator
 import io.github.graphglue.definition.RelationshipDefinition
 import io.github.graphglue.model.Node
 import io.github.graphglue.model.NodeRelationship
@@ -28,12 +29,27 @@ class NodeSubFilterDefinition(
     name: String,
     description: String,
     nodeType: KType,
-    subFilterGenerator: SubFilterGenerator,
+    private val subFilterGenerator: SubFilterGenerator,
     val relationshipDefinition: RelationshipDefinition
 ) : FilterEntryDefinition(name, description) {
 
     @Suppress("UNCHECKED_CAST")
     private val subFilter = generateFilterDefinition(nodeType.jvmErasure as KClass<out Node>, subFilterGenerator)
+
+    /**
+     * Provides a condition generator used to filter for related nodes the Permissions allows to access
+     * Used to only include nodes in relation filters which the permission allows to access.
+     * Prevents a filter information leak.
+     *
+     * @param permission the current read permission, used to only consider nodes in filters which match the permission
+     * @return the generated condition generator
+     */
+    fun generateAuthorizationCondition(permission: Permission): CypherConditionGenerator {
+        return subFilterGenerator.nodeDefinitionCollection.generateRelationshipAuthorizationCondition(
+            relationshipDefinition,
+            permission
+        )
+    }
 
     override fun parseEntry(value: Any?, permission: Permission?) =
         NodeSubFilter(this, subFilter.parseFilter(value, permission))

--- a/src/main/kotlin/io/github/graphglue/connection/filter/definition/SimpleFilterEntryDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/definition/SimpleFilterEntryDefinition.kt
@@ -2,6 +2,7 @@ package io.github.graphglue.connection.filter.definition
 
 import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLInputType
+import io.github.graphglue.authorization.Permission
 import io.github.graphglue.connection.filter.model.FilterEntry
 import io.github.graphglue.connection.filter.model.SimpleFilterEntry
 import io.github.graphglue.util.CacheMap
@@ -26,7 +27,7 @@ class SimpleFilterEntryDefinition(
     private val conditionGenerator: (property: Property, value: Expression) -> Condition
 ) : FilterEntryDefinition(name, description) {
 
-    override fun parseEntry(value: Any?): FilterEntry {
+    override fun parseEntry(value: Any?, permission: Permission?): FilterEntry {
         return SimpleFilterEntry(this, value!!)
     }
 

--- a/src/main/kotlin/io/github/graphglue/connection/filter/definition/scalars/ScalarFilterDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/definition/scalars/ScalarFilterDefinition.kt
@@ -2,6 +2,7 @@ package io.github.graphglue.connection.filter.definition.scalars
 
 import graphql.schema.GraphQLInputObjectType
 import graphql.schema.GraphQLInputType
+import io.github.graphglue.authorization.Permission
 import io.github.graphglue.connection.filter.definition.FilterEntryDefinition
 import io.github.graphglue.connection.filter.definition.SimpleObjectFilterDefinitionEntry
 import io.github.graphglue.connection.filter.model.FilterEntry
@@ -33,12 +34,12 @@ abstract class ScalarFilterDefinition(
     (entries + getDefaultFilterEntries()).map {
         it.generateFilterEntry(scalarType, neo4jName)
     }) {
-    override fun parseEntry(value: Any?): FilterEntry {
+    override fun parseEntry(value: Any?, permission: Permission?): FilterEntry {
         value as Map<*, *>
         val entries = value.map {
             val (name, entry) = it
             val definition = fields[name] ?: throw IllegalStateException("Unknown input")
-            definition.parseEntry(entry)
+            definition.parseEntry(entry, permission)
         }
         return SimpleObjectFilter(this, entries)
     }

--- a/src/main/kotlin/io/github/graphglue/connection/filter/model/NodeRelationshipFilterEntry.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/model/NodeRelationshipFilterEntry.kt
@@ -1,17 +1,7 @@
 package io.github.graphglue.connection.filter.model
 
-import io.github.graphglue.connection.filter.definition.NodeSetFilterDefinition
 import io.github.graphglue.connection.filter.definition.NodeSubFilterDefinition
 import org.neo4j.cypherdsl.core.*
-
-/**
- * [SimpleObjectFilter] with a [NodeSetFilterDefinition] definition
- *
- * @param definition associated definition of the filter
- * @param entries filter entries joined by AND
- */
-class NodeSetFilter(definition: NodeSetFilterDefinition, entries: List<NodeSetFilterEntry>) :
-    SimpleObjectFilter(definition, entries)
 
 /**
  * [FilterEntry] used to filter when the entry is a set
@@ -21,7 +11,7 @@ class NodeSetFilter(definition: NodeSetFilterDefinition, entries: List<NodeSetFi
  * @param subFilterDefinition associated definition of the entry
  * @param filter filter to filter the elements of the set
  */
-abstract class NodeSetFilterEntry(
+abstract class NodeRelationshipFilterEntry(
     private val subFilterDefinition: NodeSubFilterDefinition,
     val filter: NodeSubFilter
 ) : FilterEntry(subFilterDefinition) {
@@ -46,34 +36,34 @@ abstract class NodeSetFilterEntry(
 }
 
 /**
- * [NodeSetFilterEntry] where all of the nodes have to match the filter
+ * [NodeRelationshipFilterEntry] where all of the nodes have to match the filter
  *
  * @param definition associated definition of the entry
  * @param filter filter to filter the elements of the set
  */
-class AllNodeSetFilterEntry(definition: NodeSubFilterDefinition, filter: NodeSubFilter) :
-    NodeSetFilterEntry(definition, filter) {
+class AllNodeRelationshipFilterEntry(definition: NodeSubFilterDefinition, filter: NodeSubFilter) :
+    NodeRelationshipFilterEntry(definition, filter) {
     override fun generatePredicate(variable: SymbolicName) = Predicates.all(variable)
 }
 
 /**
- * [NodeSetFilterEntry] where any of the nodes have to match the filter
+ * [NodeRelationshipFilterEntry] where any of the nodes have to match the filter
  *
  * @param definition associated definition of the entry
  * @param filter filter to filter the elements of the set
  */
-class AnyNodeSetFilterEntry(definition: NodeSubFilterDefinition, filter: NodeSubFilter) :
-    NodeSetFilterEntry(definition, filter) {
+class AnyNodeRelationshipFilterEntry(definition: NodeSubFilterDefinition, filter: NodeSubFilter) :
+    NodeRelationshipFilterEntry(definition, filter) {
     override fun generatePredicate(variable: SymbolicName) = Predicates.any(variable)
 }
 
 /**
- * [NodeSetFilterEntry] where none of the nodes have to match the filter
+ * [NodeRelationshipFilterEntry] where none of the nodes have to match the filter
  *
  * @param definition associated definition of the entry
  * @param filter filter to filter the elements of the set
  */
-class NoneNodeSetFilterEntry(definition: NodeSubFilterDefinition, filter: NodeSubFilter) :
-    NodeSetFilterEntry(definition, filter) {
+class NoneNodeRelationshipFilterEntry(definition: NodeSubFilterDefinition, filter: NodeSubFilter) :
+    NodeRelationshipFilterEntry(definition, filter) {
     override fun generatePredicate(variable: SymbolicName) = Predicates.none(variable)
 }

--- a/src/main/kotlin/io/github/graphglue/connection/filter/model/NodeRelationshipFilterEntry.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/model/NodeRelationshipFilterEntry.kt
@@ -1,5 +1,6 @@
 package io.github.graphglue.connection.filter.model
 
+import io.github.graphglue.authorization.Permission
 import io.github.graphglue.connection.filter.definition.NodeSubFilterDefinition
 import org.neo4j.cypherdsl.core.*
 
@@ -7,21 +8,27 @@ import org.neo4j.cypherdsl.core.*
  * [FilterEntry] used to filter when the entry is a set
  * can be used for filters where either all, any or none of the elements of the set have to
  * match a filter
+ * Automatically includes a condition which checks that the filter does not include any nodes which the
+ * provided Permission (if provided) does not allow to access. This prevents information leakage using filters.
+ * Without this, it would be possible to get information of related nodes by brute-forcing different filters
+ * (e.g. getting one character of a name at a time by checking if the related node is still returned).
  *
  * @param subFilterDefinition associated definition of the entry
  * @param filter filter to filter the elements of the set
+ * @param permission the current read permission, used to only consider nodes in filters which match the permission
  */
 abstract class NodeRelationshipFilterEntry(
     private val subFilterDefinition: NodeSubFilterDefinition,
-    val filter: NodeSubFilter
+    val filter: NodeSubFilter,
+    private val permission: Permission?
 ) : FilterEntry(subFilterDefinition) {
     override fun generateCondition(node: Node): Condition {
         val relationshipDefinition = subFilterDefinition.relationshipDefinition
         val relatedNode = Cypher.anyNode(node.requiredSymbolicName.value + "_")
         val relationship = relationshipDefinition.generateRelationship(node, relatedNode)
-        return generatePredicate(relatedNode.requiredSymbolicName)
-            .`in`(Cypher.listBasedOn(relationship).returning(relatedNode))
-            .where(filter.generateCondition(relatedNode))
+        return generatePredicate(relatedNode.requiredSymbolicName).`in`(
+            Cypher.listBasedOn(relationship).returning(relatedNode)
+        ).where(filter.generateCondition(relatedNode))
     }
 
     /**
@@ -40,9 +47,11 @@ abstract class NodeRelationshipFilterEntry(
  *
  * @param definition associated definition of the entry
  * @param filter filter to filter the elements of the set
+ * @param permission the current read permission, used to only consider nodes in filters which match the permission
  */
-class AllNodeRelationshipFilterEntry(definition: NodeSubFilterDefinition, filter: NodeSubFilter) :
-    NodeRelationshipFilterEntry(definition, filter) {
+class AllNodeRelationshipFilterEntry(
+    definition: NodeSubFilterDefinition, filter: NodeSubFilter, permission: Permission?
+) : NodeRelationshipFilterEntry(definition, filter, permission) {
     override fun generatePredicate(variable: SymbolicName) = Predicates.all(variable)
 }
 
@@ -51,9 +60,11 @@ class AllNodeRelationshipFilterEntry(definition: NodeSubFilterDefinition, filter
  *
  * @param definition associated definition of the entry
  * @param filter filter to filter the elements of the set
+ * @param permission the current read permission, used to only consider nodes in filters which match the permission
  */
-class AnyNodeRelationshipFilterEntry(definition: NodeSubFilterDefinition, filter: NodeSubFilter) :
-    NodeRelationshipFilterEntry(definition, filter) {
+class AnyNodeRelationshipFilterEntry(
+    definition: NodeSubFilterDefinition, filter: NodeSubFilter, permission: Permission?
+) : NodeRelationshipFilterEntry(definition, filter, permission) {
     override fun generatePredicate(variable: SymbolicName) = Predicates.any(variable)
 }
 
@@ -62,8 +73,10 @@ class AnyNodeRelationshipFilterEntry(definition: NodeSubFilterDefinition, filter
  *
  * @param definition associated definition of the entry
  * @param filter filter to filter the elements of the set
+ * @param permission the current read permission, used to only consider nodes in filters which match the permission
  */
-class NoneNodeRelationshipFilterEntry(definition: NodeSubFilterDefinition, filter: NodeSubFilter) :
-    NodeRelationshipFilterEntry(definition, filter) {
+class NoneNodeRelationshipFilterEntry(
+    definition: NodeSubFilterDefinition, filter: NodeSubFilter, permission: Permission?
+) : NodeRelationshipFilterEntry(definition, filter, permission) {
     override fun generatePredicate(variable: SymbolicName) = Predicates.none(variable)
 }

--- a/src/main/kotlin/io/github/graphglue/connection/filter/model/NodeSetPropertyFilter.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/model/NodeSetPropertyFilter.kt
@@ -1,0 +1,12 @@
+package io.github.graphglue.connection.filter.model
+
+import io.github.graphglue.connection.filter.definition.NodeSetPropertyFilterDefinition
+
+/**
+ * [SimpleObjectFilter] with a [NodeSetPropertyFilterDefinition] definition
+ *
+ * @param definition associated definition of the filter
+ * @param entries filter entries joined by AND
+ */
+class NodeSetPropertyFilter(definition: NodeSetPropertyFilterDefinition, entries: List<NodeRelationshipFilterEntry>) :
+    SimpleObjectFilter(definition, entries)

--- a/src/main/kotlin/io/github/graphglue/data/execution/NodeQueryParser.kt
+++ b/src/main/kotlin/io/github/graphglue/data/execution/NodeQueryParser.kt
@@ -319,7 +319,7 @@ class NodeQueryParser(
         val filterDefinition = filterDefinitionCollection.getFilterDefinition<Node>(nodeDefinition.nodeType)
         val filters = ArrayList(additionalConditions)
         arguments["filter"]?.also {
-            filters.add(filterDefinition.parseFilter(it))
+            filters.add(filterDefinition.parseFilter(it, requiredPermission))
         }
         val orderBy = arguments["orderBy"]?.let { parseOrder(it) } ?: IdOrder
         val subNodeQueryOptions = NodeQueryOptions(

--- a/src/main/kotlin/io/github/graphglue/definition/generateNodeDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/definition/generateNodeDefinition.kt
@@ -36,7 +36,7 @@ fun generateNodeDefinition(nodeClass: KClass<out Node>, mappingContext: Neo4jMap
  */
 private fun generateOneRelationshipDefinitions(nodeClass: KClass<out Node>): List<OneRelationshipDefinition> {
     val properties = nodeClass.memberProperties.filter {
-        it.returnType.isSubtypeOf(Node::class.createType()) && it.returnType.classifier !is KTypeParameter
+        it.returnType.isSubtypeOf(Node::class.createType(nullable = true)) && it.returnType.classifier !is KTypeParameter
     }
     return properties.map {
         val field = it.javaField

--- a/website/docs/modeling.mdx
+++ b/website/docs/modeling.mdx
@@ -235,6 +235,16 @@ fun floatFilter() =
     }
 ```
 
+:::info
+
+Filter on `NodeProperty<*>` and `NodeSetProperty<*>` take the authorization system into account.
+Conceptually, first the related nodes are filtered by the `Permission` to only include nodes the Permission grants access to, then,
+the filter is evaluated. 
+This prevents an information leak by filtering, however, at the cost of higher complexity. 
+Therefore, use `@FilterProperty` on properties which may include non-visible nodes with caution.
+
+:::
+
 #### Additional filters
 
 With the `AdditionalFilter("beanName")` annotation, property independent filters can be defined.


### PR DESCRIPTION
- Allows `@FilterProperty` on nullable node properties
- Fixes filter generation for node properties
- Adds a permission check to the filter evaluation to prevent an information leak due to filtering. This allows annotating properties with `@FilterProperty` even if the property may contain nodes which are not visible