### PR TITLE
add GraphQLNullable, bugfixes

### DIFF
--- a/src/main/kotlin/io/github/graphglue/definition/OneRelationshipDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/definition/OneRelationshipDefinition.kt
@@ -6,9 +6,11 @@ import graphql.schema.GraphQLTypeReference
 import io.github.graphglue.graphql.schema.SchemaTransformationContext
 import io.github.graphglue.graphql.extensions.getSimpleName
 import io.github.graphglue.model.Direction
+import io.github.graphglue.model.GraphQLNullable
 import io.github.graphglue.model.Node
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
+import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.jvm.jvmErasure
 
 /**
@@ -32,7 +34,7 @@ class OneRelationshipDefinition(
     override fun generateFieldDefinition(transformationContext: SchemaTransformationContext): GraphQLFieldDefinition {
         val type = property.returnType
         val graphQLType = GraphQLTypeReference(type.jvmErasure.getSimpleName()).let {
-            if (type.isMarkedNullable) {
+            if (type.isMarkedNullable || property.hasAnnotation<GraphQLNullable>()) {
                 it
             } else {
                 GraphQLNonNull(it)

--- a/src/main/kotlin/io/github/graphglue/model/FilterProperty.kt
+++ b/src/main/kotlin/io/github/graphglue/model/FilterProperty.kt
@@ -1,5 +1,13 @@
 package io.github.graphglue.model
 
+import io.github.graphglue.connection.filter.TypeFilterDefinitionEntry
+
+/**
+ * Annotation to mark properties as filter property, meaning that the filter for the class
+ * containing the property gets a field added defined by the property.
+ * Supported for Node(Set)Property backed properties, and scalar properties.
+ * Other properties can be supported by providing a [TypeFilterDefinitionEntry] for the type of property.
+ */
 @Target(AnnotationTarget.PROPERTY)
 @MustBeDocumented
 annotation class FilterProperty

--- a/src/main/kotlin/io/github/graphglue/model/GraphQLNullable.kt
+++ b/src/main/kotlin/io/github/graphglue/model/GraphQLNullable.kt
@@ -1,0 +1,10 @@
+package io.github.graphglue.model
+
+/**
+ * Annotation to mark [NodeProperty]s in GraphQL as nullable, even if the Kotlin Type is non-nullable.
+ * Necessary, as authorization may lead to a Node not always being provided if the user has no permission
+ * to read the node.
+ */
+@Target(AnnotationTarget.PROPERTY)
+@MustBeDocumented
+annotation class GraphQLNullable

--- a/src/main/kotlin/io/github/graphglue/model/OrderProperty.kt
+++ b/src/main/kotlin/io/github/graphglue/model/OrderProperty.kt
@@ -1,5 +1,10 @@
 package io.github.graphglue.model
 
+/**
+ * Annotation to mark properties as order properties, meaning that nodes of the containing class can be ordered
+ * by this property. Necessary that the property is a scalar property and of an in Neo4j orderable type
+ * (e.g. String, Int, Double, ...)
+ */
 @MustBeDocumented
 @Target(AnnotationTarget.PROPERTY)
 annotation class OrderProperty


### PR DESCRIPTION
- adds a `GraphQLNullable` annotation which can be used to make `NodeProperty` backed properties nullable, even if the Kotlin type is non-nullable, necessary as authorization may prevent returning node even if present
- adds missing documentation for `FilterProperty` and `OrderProperty`
- fixes a bug where relations are sometimes not fetched when using `... on` in GraphQL