### PR TITLE
add NodeFilterGenerator

### DIFF
--- a/src/main/kotlin/io/github/graphglue/connection/filter/NodeFilterGenerator.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/NodeFilterGenerator.kt
@@ -1,0 +1,26 @@
+package io.github.graphglue.connection.filter
+
+import io.github.graphglue.connection.filter.definition.FilterEntryDefinition
+import io.github.graphglue.connection.filter.definition.SubFilterGenerator
+import io.github.graphglue.definition.NodeDefinition
+import io.github.graphglue.model.Node
+
+/**
+ * Interface which can be used to provide beans which provide additional filter entries
+ * for specific node filters.
+ * Can be used to generate additional filter entries
+ */
+fun interface NodeFilterGenerator {
+
+    /**
+     * Generate the additional filter entries
+     *
+     * @param definition the definition of the [Node] to generate the filter entry for
+     * @param subFilterGenerator can be used to generate subfilters if necessary
+     * @return the generated filter entries, may be empty
+     */
+    fun generateFilterEntries(
+        definition: NodeDefinition, subFilterGenerator: SubFilterGenerator
+    ): Collection<FilterEntryDefinition>
+
+}

--- a/src/main/kotlin/io/github/graphglue/connection/filter/definition/SubFilterGenerator.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/definition/SubFilterGenerator.kt
@@ -1,5 +1,6 @@
 package io.github.graphglue.connection.filter.definition
 
+import io.github.graphglue.connection.filter.NodeFilterGenerator
 import io.github.graphglue.definition.NodeDefinition
 import io.github.graphglue.connection.filter.TypeFilterDefinitionEntry
 import io.github.graphglue.definition.NodeDefinitionCollection
@@ -18,12 +19,14 @@ import kotlin.reflect.jvm.jvmErasure
  * @param filterDefinitionCache cache of already generated filters for [Node] types
  * @param nodeDefinitionCollection cache of already generated [NodeDefinition]s
  * @param additionalFilterBeans lookup for filters defined using the [AdditionalFilter] annotation
+ * @param nodeFilterGenerators generators for additional filter entries
  */
 class SubFilterGenerator(
     private val filters: List<TypeFilterDefinitionEntry>,
     val filterDefinitionCache: FilterDefinitionCache,
     val nodeDefinitionCollection: NodeDefinitionCollection,
-    val additionalFilterBeans: Map<String, FilterEntryDefinition>
+    val additionalFilterBeans: Map<String, FilterEntryDefinition>,
+    val nodeFilterGenerators: List<NodeFilterGenerator>
 ) {
 
     /**

--- a/src/main/kotlin/io/github/graphglue/connection/filter/definition/generateFilterDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/definition/generateFilterDefinition.kt
@@ -29,6 +29,9 @@ fun generateFilterDefinition(
         val additionalFilters = additionalFilterAnnotations.map {
             subFilterGenerator.additionalFilterBeans[it.beanName]!!
         }
-        it.init(filterFields + additionalFilters)
+        val generatedFilters = subFilterGenerator.nodeFilterGenerators.flatMap { generator ->
+            generator.generateFilterEntries(nodeDefinition, subFilterGenerator)
+        }
+        it.init(filterFields + additionalFilters + generatedFilters)
     }
 }

--- a/website/docs/modeling.mdx
+++ b/website/docs/modeling.mdx
@@ -137,28 +137,32 @@ For more information, see [Connecting nodes: @Relationship](https://docs.spring.
 ### Comparison
 
 <table>
-    <tr>
-        <th></th>
-        <th>GraphGlue</th>
-        <th>Spring Data Neo4j </th>
-    </tr>
-    <tr>
-        <th>GraphQL representation</th>
-        <th>One sides are represented by their appropriate type. Many sides are represented by connection types, supporting pagination, filtering and ordering</th>
-        <th>One sides are represented by their appropriate type. Many sides are represented as GraphQL list, without pagination, filtering or ordering support</th>
-    </tr>
-    <tr>
-        <th>Lazy loading</th>
-        <th>Only lazy loading is supported. Relations are automatically loaded when accessed. Note: when fetching data for GraphQL, the whole subtree is loaded at once using one Cypher query, preventing the n+1 problem.</th>
-        <th>
-            No lazy loading is supported, all relationships are eagerly loaded, which can result in large subgraphs being loaded. To prevent this, you may use 
-            <a href="https://docs.spring.io/spring-data/neo4j/docs/current/reference/html/#projections" rel="noopener noreferer">Projections</a>
-        </th>
-    </tr>
-    <tr>
-        <th>Matching of opposite sides</th>
-        <th colspan="2">Opposite sides are matched if the `label` is the same, but the `direction` the opposite.</th>
-    </tr>
+    <thead>
+        <tr>
+            <th></th>
+            <th>GraphGlue</th>
+            <th>Spring Data Neo4j </th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>GraphQL representation</th>
+            <th>One sides are represented by their appropriate type. Many sides are represented by connection types, supporting pagination, filtering and ordering</th>
+            <th>One sides are represented by their appropriate type. Many sides are represented as GraphQL list, without pagination, filtering or ordering support</th>
+        </tr>
+        <tr>
+            <th>Lazy loading</th>
+            <th>Only lazy loading is supported. Relations are automatically loaded when accessed. Note: when fetching data for GraphQL, the whole subtree is loaded at once using one Cypher query, preventing the n+1 problem.</th>
+            <th>
+                No lazy loading is supported, all relationships are eagerly loaded, which can result in large subgraphs being loaded. To prevent this, you may use 
+                <a href="https://docs.spring.io/spring-data/neo4j/docs/current/reference/html/#projections" rel="noopener noreferer">Projections</a>
+            </th>
+        </tr>
+        <tr>
+            <th>Matching of opposite sides</th>
+            <th colSpan="2">Opposite sides are matched if the `label` is the same, but the `direction` the opposite.</th>
+        </tr>
+    </tbody>
 </table>
 
 ## Inheritance
@@ -250,3 +254,9 @@ Therefore, use `@FilterProperty` on properties which may include non-visible nod
 With the `AdditionalFilter("beanName")` annotation, property independent filters can be defined.
 This can for instance be used to filter by Node type, or a complex condition.
 A Spring bean with the specified name and type `FilterEntryDefinition` has to be provided.
+
+#### Node filter generators
+
+Bean of type `NodeFilterGenerator` can be used to generate additional filter entries for any Node filters.
+In contrast to [Additional filters](#additional-filters), node filter generators allow for dynamically generating the entries
+based on the provided `NodeDefinition`, which allows e.g. implementing custom meta-filters (like xor).


### PR DESCRIPTION
- adds `NodeFilterGenerator` which allows adding custom filter entries dynamically, can e.g. be used for custom meta-filter entries
- fixes a bug in the documentation