### PR TITLE
Feature/reactive lazy loading

### DIFF
--- a/src/main/kotlin/io/github/graphglue/connection/GraphglueConnectionConfiguration.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/GraphglueConnectionConfiguration.kt
@@ -8,6 +8,10 @@ import io.github.graphglue.connection.filter.definition.NodeSubFilterDefinition
 import io.github.graphglue.connection.filter.definition.scalars.*
 import io.github.graphglue.definition.extensions.firstTypeArgument
 import io.github.graphglue.model.*
+import io.github.graphglue.model.property.NodePropertyDelegate
+import io.github.graphglue.model.property.NodeSetPropertyDelegate
+import io.github.graphglue.model.property.NODE_PROPERTY_TYPE
+import io.github.graphglue.model.property.NODE_SET_PROPERTY_TYPE
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import kotlin.reflect.full.createType
@@ -16,7 +20,7 @@ import kotlin.reflect.full.createType
  * Configuration for the connections
  * Specifies filter factories and filter definitions used in [Node] classes.
  * Defines filter factories for [String], [Int], [Float] and [ID] scalar properties (including nullable)
- * and for properties backed by [NodeProperty] and [NodeSetProperty]
+ * and for properties backed by [NodePropertyDelegate] and [NodeSetPropertyDelegate]
  */
 @Configuration
 class GraphglueConnectionConfiguration {
@@ -98,7 +102,7 @@ class GraphglueConnectionConfiguration {
 
     /**
      * Filter factory for [Node] properties
-     * These properties should always be backed by a [NodeProperty]
+     * These properties should always be backed by a [NodePropertyDelegate]
      *
      * @return the generated filter factory
      */
@@ -119,7 +123,7 @@ class GraphglueConnectionConfiguration {
 
     /**
      * Filter factory for `Set<Node>` properties
-     * These properties should always be backed by a [NodeSetProperty]
+     * These properties should always be backed by a [NodeSetPropertyDelegate]
      *
      * @return the generated filter factory
      */
@@ -127,10 +131,10 @@ class GraphglueConnectionConfiguration {
     fun nodeSetFilter() =
         TypeFilterDefinitionEntry(NODE_SET_PROPERTY_TYPE) { name, property, parentNodeDefinition, subFilterGenerator ->
             println(property.returnType.firstTypeArgument)
-            println(property.returnType.firstTypeArgument.firstTypeArgument)
+            println(property.returnType.firstTypeArgument)
             NodeSetPropertyFilterDefinition(
                 name,
-                property.returnType.firstTypeArgument.firstTypeArgument,
+                property.returnType.firstTypeArgument,
                 subFilterGenerator,
                 parentNodeDefinition.getRelationshipDefinitionOfProperty(property)
             )

--- a/src/main/kotlin/io/github/graphglue/connection/GraphglueConnectionConfiguration.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/GraphglueConnectionConfiguration.kt
@@ -6,12 +6,10 @@ import io.github.graphglue.connection.filter.definition.NodePropertyFilterDefini
 import io.github.graphglue.connection.filter.definition.NodeSetPropertyFilterDefinition
 import io.github.graphglue.connection.filter.definition.NodeSubFilterDefinition
 import io.github.graphglue.connection.filter.definition.scalars.*
-import io.github.graphglue.model.Node
-import io.github.graphglue.model.NodeProperty
-import io.github.graphglue.model.NodeSetProperty
+import io.github.graphglue.definition.extensions.firstTypeArgument
+import io.github.graphglue.model.*
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import kotlin.reflect.KTypeProjection
 import kotlin.reflect.full.createType
 
 /**
@@ -106,11 +104,13 @@ class GraphglueConnectionConfiguration {
      */
     @Bean
     fun nodeFilter() =
-        TypeFilterDefinitionEntry(Node::class.createType(nullable = true)) { name, property, parentNodeDefinition, subFilterGenerator ->
+        TypeFilterDefinitionEntry(NODE_PROPERTY_TYPE) { name, property, parentNodeDefinition, subFilterGenerator ->
+            println("here????")
+            println(property.returnType.firstTypeArgument)
             val nodeSubFilterDefinition = NodeSubFilterDefinition(
                 name,
                 "Filters for nodes where the related node match this filter",
-                property.returnType,
+                property.returnType.firstTypeArgument,
                 subFilterGenerator,
                 parentNodeDefinition.getRelationshipDefinitionOfProperty(property)
             )
@@ -125,10 +125,12 @@ class GraphglueConnectionConfiguration {
      */
     @Bean
     fun nodeSetFilter() =
-        TypeFilterDefinitionEntry(Set::class.createType(listOf(KTypeProjection.covariant(Node::class.createType())))) { name, property, parentNodeDefinition, subFilterGenerator ->
+        TypeFilterDefinitionEntry(NODE_SET_PROPERTY_TYPE) { name, property, parentNodeDefinition, subFilterGenerator ->
+            println(property.returnType.firstTypeArgument)
+            println(property.returnType.firstTypeArgument.firstTypeArgument)
             NodeSetPropertyFilterDefinition(
                 name,
-                property.returnType.arguments.first().type!!,
+                property.returnType.firstTypeArgument.firstTypeArgument,
                 subFilterGenerator,
                 parentNodeDefinition.getRelationshipDefinitionOfProperty(property)
             )

--- a/src/main/kotlin/io/github/graphglue/connection/generateConnectionFieldDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/generateConnectionFieldDefinition.kt
@@ -8,8 +8,8 @@ import io.github.graphglue.connection.order.OrderField
 import io.github.graphglue.connection.order.generateOrders
 import io.github.graphglue.graphql.schema.SchemaTransformationContext
 import io.github.graphglue.graphql.extensions.getSimpleName
-import io.github.graphglue.model.Connection
-import io.github.graphglue.model.Edge
+import io.github.graphglue.connection.model.Connection
+import io.github.graphglue.connection.model.Edge
 import io.github.graphglue.model.Node
 import kotlin.reflect.KClass
 

--- a/src/main/kotlin/io/github/graphglue/connection/model/Connection.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/model/Connection.kt
@@ -1,4 +1,4 @@
-package io.github.graphglue.model
+package io.github.graphglue.connection.model
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.execution.DataFetcherResult
@@ -6,6 +6,7 @@ import graphql.schema.DataFetchingEnvironment
 import io.github.graphglue.data.execution.NodeQueryResult
 import io.github.graphglue.connection.order.Order
 import io.github.graphglue.graphql.extensions.getDataFetcherResult
+import io.github.graphglue.model.Node
 
 /**
  * Connection used as ObjectType in the GraphQL API

--- a/src/main/kotlin/io/github/graphglue/connection/model/Edge.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/model/Edge.kt
@@ -1,4 +1,4 @@
-package io.github.graphglue.model
+package io.github.graphglue.connection.model
 
 import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -6,6 +6,7 @@ import graphql.execution.DataFetcherResult
 import graphql.schema.DataFetchingEnvironment
 import io.github.graphglue.connection.order.Order
 import io.github.graphglue.graphql.extensions.getDataFetcherResult
+import io.github.graphglue.model.Node
 import org.springframework.beans.factory.annotation.Autowired
 
 /**

--- a/src/main/kotlin/io/github/graphglue/connection/model/PageInfo.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/model/PageInfo.kt
@@ -1,9 +1,10 @@
-package io.github.graphglue.model
+package io.github.graphglue.connection.model
 
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.graphglue.data.execution.NodeQueryOptions
 import io.github.graphglue.connection.order.Order
+import io.github.graphglue.model.Node
 
 /**
  * Page info used in GraphQL connection to provide general pagination information

--- a/src/main/kotlin/io/github/graphglue/data/GraphglueDataConfiguration.kt
+++ b/src/main/kotlin/io/github/graphglue/data/GraphglueDataConfiguration.kt
@@ -67,21 +67,6 @@ class GraphglueDataConfiguration {
         return LazyLoadingContext(neo4jClient, neo4jMappingContext, nodeQueryParser)
     }
 
-    /**
-     * Creates a [ReactiveNeo4jTransactionManager] to provide transaction functionality
-     *
-     * @param driver the driver for the Neo4j database
-     * @param databaseNameProvider provides the name of the database
-     */
-    @Bean
-    @ConditionalOnMissingBean
-    fun reactiveTransactionManager(
-        driver: Driver,
-        databaseNameProvider: ReactiveDatabaseSelectionProvider
-    ): ReactiveNeo4jTransactionManager {
-        return ReactiveNeo4jTransactionManager(driver, databaseNameProvider)
-    }
-
     /***
      * Bean to provide [Neo4jOperations] which support save over lazy loaded relations
      *

--- a/src/main/kotlin/io/github/graphglue/definition/ManyRelationshipDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/definition/ManyRelationshipDefinition.kt
@@ -2,6 +2,7 @@ package io.github.graphglue.definition
 
 import graphql.schema.GraphQLFieldDefinition
 import io.github.graphglue.connection.generateConnectionFieldDefinition
+import io.github.graphglue.definition.extensions.firstTypeArgument
 import io.github.graphglue.graphql.schema.SchemaTransformationContext
 import io.github.graphglue.model.Direction
 import io.github.graphglue.model.Node
@@ -19,20 +20,17 @@ import kotlin.reflect.jvm.jvmErasure
  *                        must be a subclass of the property defining class
  */
 class ManyRelationshipDefinition(
-    property: KProperty1<*, *>,
-    type: String,
-    direction: Direction,
-    parentKClass: KClass<out Node>
+    property: KProperty1<*, *>, type: String, direction: Direction, parentKClass: KClass<out Node>
 ) : RelationshipDefinition(
     property,
-    @Suppress("UNCHECKED_CAST") (property.returnType.arguments.first().type!!.jvmErasure as KClass<out Node>),
+    @Suppress("UNCHECKED_CAST") (property.returnType.firstTypeArgument.firstTypeArgument.jvmErasure as KClass<out Node>),
     type,
     direction,
     parentKClass
 ) {
     override fun generateFieldDefinition(transformationContext: SchemaTransformationContext): GraphQLFieldDefinition {
         @Suppress("UNCHECKED_CAST") val returnNodeType =
-            property.returnType.arguments[0].type!!.jvmErasure as KClass<out Node>
+            property.returnType.firstTypeArgument.firstTypeArgument.jvmErasure as KClass<out Node>
         return generateConnectionFieldDefinition(returnNodeType, graphQLName, graphQLDescription, transformationContext)
     }
 }

--- a/src/main/kotlin/io/github/graphglue/definition/ManyRelationshipDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/definition/ManyRelationshipDefinition.kt
@@ -23,14 +23,14 @@ class ManyRelationshipDefinition(
     property: KProperty1<*, *>, type: String, direction: Direction, parentKClass: KClass<out Node>
 ) : RelationshipDefinition(
     property,
-    @Suppress("UNCHECKED_CAST") (property.returnType.firstTypeArgument.firstTypeArgument.jvmErasure as KClass<out Node>),
+    @Suppress("UNCHECKED_CAST") (property.returnType.firstTypeArgument.jvmErasure as KClass<out Node>),
     type,
     direction,
     parentKClass
 ) {
     override fun generateFieldDefinition(transformationContext: SchemaTransformationContext): GraphQLFieldDefinition {
         @Suppress("UNCHECKED_CAST") val returnNodeType =
-            property.returnType.firstTypeArgument.firstTypeArgument.jvmErasure as KClass<out Node>
+            property.returnType.firstTypeArgument.jvmErasure as KClass<out Node>
         return generateConnectionFieldDefinition(returnNodeType, graphQLName, graphQLDescription, transformationContext)
     }
 }

--- a/src/main/kotlin/io/github/graphglue/definition/OneRelationshipDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/definition/OneRelationshipDefinition.kt
@@ -3,6 +3,7 @@ package io.github.graphglue.definition
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLNonNull
 import graphql.schema.GraphQLTypeReference
+import io.github.graphglue.definition.extensions.firstTypeArgument
 import io.github.graphglue.graphql.schema.SchemaTransformationContext
 import io.github.graphglue.graphql.extensions.getSimpleName
 import io.github.graphglue.model.Direction
@@ -26,13 +27,13 @@ class OneRelationshipDefinition(
     property: KProperty1<*, *>, type: String, direction: Direction, parentKClass: KClass<out Node>
 ) : RelationshipDefinition(
     property,
-    @Suppress("UNCHECKED_CAST") (property.returnType.jvmErasure as KClass<out Node>),
+    @Suppress("UNCHECKED_CAST") (property.returnType.firstTypeArgument.jvmErasure as KClass<out Node>),
     type,
     direction,
     parentKClass
 ) {
     override fun generateFieldDefinition(transformationContext: SchemaTransformationContext): GraphQLFieldDefinition {
-        val type = property.returnType
+        val type = property.returnType.firstTypeArgument
         val graphQLType = GraphQLTypeReference(type.jvmErasure.getSimpleName()).let {
             if (type.isMarkedNullable || property.hasAnnotation<GraphQLNullable>()) {
                 it

--- a/src/main/kotlin/io/github/graphglue/definition/RelationshipDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/definition/RelationshipDefinition.kt
@@ -9,8 +9,8 @@ import io.github.graphglue.graphql.schema.SchemaTransformationContext
 import io.github.graphglue.graphql.extensions.getPropertyName
 import io.github.graphglue.model.Direction
 import io.github.graphglue.model.Node
-import io.github.graphglue.model.NodeProperty
 import io.github.graphglue.model.NodeRelationship
+import io.github.graphglue.model.property.NodePropertyDelegate
 import org.neo4j.cypherdsl.core.ExposesPatternLengthAccessors
 import org.neo4j.cypherdsl.core.ExposesRelationships
 import org.neo4j.cypherdsl.core.RelationshipPattern
@@ -74,7 +74,7 @@ abstract class RelationshipDefinition(
             if (annotation?.type == type && annotation.direction != direction) {
                 if (remoteProperty.returnType.isSubtypeOf(Node::class.createType())) {
                     return { remoteNode, value ->
-                        val nodeProperty = remoteNode.getProperty<Node?>(remoteProperty) as NodeProperty<Node?>
+                        val nodeProperty = remoteNode.getProperty<Node?>(remoteProperty) as NodePropertyDelegate<Node?>
                         nodeProperty.setFromRemote(value)
                     }
                 }

--- a/src/main/kotlin/io/github/graphglue/definition/extensions/kTypeExtensions.kt
+++ b/src/main/kotlin/io/github/graphglue/definition/extensions/kTypeExtensions.kt
@@ -1,0 +1,8 @@
+package io.github.graphglue.definition.extensions
+
+import kotlin.reflect.KType
+
+/**
+ * Helper to get the type of the first type argument
+ */
+val KType.firstTypeArgument get() = arguments.first().type!!

--- a/src/main/kotlin/io/github/graphglue/definition/generateNodeDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/definition/generateNodeDefinition.kt
@@ -2,6 +2,9 @@ package io.github.graphglue.definition
 
 import io.github.graphglue.definition.extensions.firstTypeArgument
 import io.github.graphglue.model.*
+import io.github.graphglue.model.property.NODE_PROPERTY_TYPE
+import io.github.graphglue.model.property.NODE_SET_PROPERTY_TYPE
+import io.github.graphglue.model.property.NodePropertyDelegate
 import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext
 import org.springframework.data.neo4j.core.mapping.Neo4jPersistentEntity
 import kotlin.reflect.KClass
@@ -40,7 +43,7 @@ private fun generateOneRelationshipDefinitions(nodeClass: KClass<out Node>): Lis
 
     return properties.map {
         val field = it.javaField
-        if (field == null || !field.type.kotlin.isSubclassOf(NodeProperty::class)) {
+        if (field == null || !field.type.kotlin.isSubclassOf(NodePropertyDelegate::class)) {
             throw NodeSchemaException("Property of type Node is not backed by a NodeProperty: $it")
         }
         val annotation = it.findAnnotation<NodeRelationship>()
@@ -57,7 +60,7 @@ private fun generateOneRelationshipDefinitions(nodeClass: KClass<out Node>): Lis
  */
 private fun generateManyRelationshipDefinitions(nodeClass: KClass<out Node>): List<ManyRelationshipDefinition> {
     val properties = nodeClass.memberProperties.filter { it.returnType.isSubtypeOf(NODE_SET_PROPERTY_TYPE) }.filter {
-        it.returnType.firstTypeArgument.firstTypeArgument.classifier !is KTypeParameter
+        it.returnType.firstTypeArgument.classifier !is KTypeParameter
     }
     return properties.map {
         val annotation = it.findAnnotation<NodeRelationship>()

--- a/src/main/kotlin/io/github/graphglue/graphql/GraphglueGraphQLConfiguration.kt
+++ b/src/main/kotlin/io/github/graphglue/graphql/GraphglueGraphQLConfiguration.kt
@@ -29,10 +29,9 @@ import io.github.graphglue.definition.generateNodeDefinition
 import io.github.graphglue.graphql.extensions.toTopLevelObjects
 import io.github.graphglue.graphql.query.GraphglueQuery
 import io.github.graphglue.graphql.schema.DefaultSchemaTransformer
-import io.github.graphglue.model.BaseProperty
 import io.github.graphglue.model.Node
 import io.github.graphglue.model.NodeRelationship
-import io.github.graphglue.model.PageInfo
+import io.github.graphglue.connection.model.PageInfo
 import io.github.graphglue.util.CacheMap
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.BeanFactory
@@ -193,7 +192,7 @@ class GraphglueGraphQLConfiguration(private val neo4jMappingContext: Neo4jMappin
         schema.filterDefinitionCollection
 
     /**
-     * [SchemaGeneratorHooks] which handles rewiring of [BaseProperty] backed files,
+     * [SchemaGeneratorHooks] which handles rewiring of [BasePropertyDelegate] backed files,
      * collects all [Node] types and generates [NodeDefinition]s for it, and collects queries
      * for [Node] types
      *

--- a/src/main/kotlin/io/github/graphglue/graphql/query/TopLevelQueryProvider.kt
+++ b/src/main/kotlin/io/github/graphglue/graphql/query/TopLevelQueryProvider.kt
@@ -10,7 +10,7 @@ import io.github.graphglue.data.execution.NodeQueryParser
 import io.github.graphglue.data.execution.NodeQueryResult
 import io.github.graphglue.definition.NodeDefinition
 import io.github.graphglue.graphql.extensions.requiredPermission
-import io.github.graphglue.model.Connection
+import io.github.graphglue.connection.model.Connection
 import io.github.graphglue.model.Node
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.neo4j.core.ReactiveNeo4jClient

--- a/src/main/kotlin/io/github/graphglue/graphql/schema/DefaultSchemaTransformer.kt
+++ b/src/main/kotlin/io/github/graphglue/graphql/schema/DefaultSchemaTransformer.kt
@@ -14,9 +14,9 @@ import io.github.graphglue.definition.RelationshipDefinition
 import io.github.graphglue.graphql.extensions.getSimpleName
 import io.github.graphglue.graphql.extensions.springFindAnnotation
 import io.github.graphglue.graphql.query.TopLevelQueryProvider
-import io.github.graphglue.model.BaseProperty
 import io.github.graphglue.model.DomainNode
 import io.github.graphglue.model.Node
+import io.github.graphglue.model.property.BasePropertyDelegate
 import io.github.graphglue.util.CacheMap
 import org.springframework.data.neo4j.core.mapping.Neo4jMappingContext
 import kotlin.reflect.full.allSuperclasses
@@ -176,7 +176,7 @@ class DefaultSchemaTransformer(
     ) {
         val kProperty = relationshipDefinition.property
         val functionDataFetcherFactory =
-            dataFetcherFactoryProvider.functionDataFetcherFactory(null, BaseProperty<*>::getFromGraphQL)
+            dataFetcherFactoryProvider.functionDataFetcherFactory(null, BasePropertyDelegate<*, *>::getFromGraphQL)
         val dataFetcherFactory = DataFetcherFactory { dataFetcherFactoryEnvironment ->
             val functionDataFetcher = functionDataFetcherFactory.get(dataFetcherFactoryEnvironment)
             DataFetcher {

--- a/src/main/kotlin/io/github/graphglue/graphql/schema/DelegateDataFetchingEnvironment.kt
+++ b/src/main/kotlin/io/github/graphglue/graphql/schema/DelegateDataFetchingEnvironment.kt
@@ -1,7 +1,7 @@
 package io.github.graphglue.graphql.schema
 
 import graphql.schema.DataFetchingEnvironment
-import io.github.graphglue.model.BaseProperty
+import io.github.graphglue.model.property.BasePropertyDelegate
 
 /**
  * [DataFetchingEnvironment] which delegates all functionality to [parent], except for [getSource], which returns
@@ -11,7 +11,7 @@ import io.github.graphglue.model.BaseProperty
  * @param source the override for [getSource]
  */
 class DelegateDataFetchingEnvironment(
-    private val parent: DataFetchingEnvironment, private val source: BaseProperty<*>
+    private val parent: DataFetchingEnvironment, private val source: BasePropertyDelegate<*, *>
 ) : DataFetchingEnvironment by parent {
 
     @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/io/github/graphglue/model/BaseProperty.kt
+++ b/src/main/kotlin/io/github/graphglue/model/BaseProperty.kt
@@ -103,4 +103,11 @@ abstract class BaseProperty<T : Node?>(protected val parent: Node, protected val
      * Gets [Node]s which should be persisted when this [Node] is persisted
      */
     internal abstract fun getRelatedNodesToSave(): Collection<Node>
+
+    /**
+     * Marker for lazy loading delegates, necessary for property type based filter & order generation
+     *
+     * @param R the type of the property
+     */
+    interface LazyLoadingDelegate<R>
 }

--- a/src/main/kotlin/io/github/graphglue/model/GraphQLNullable.kt
+++ b/src/main/kotlin/io/github/graphglue/model/GraphQLNullable.kt
@@ -1,7 +1,7 @@
 package io.github.graphglue.model
 
 /**
- * Annotation to mark [NodeProperty]s in GraphQL as nullable, even if the Kotlin Type is non-nullable.
+ * Annotation to mark [NodePropertyDelegate]s in GraphQL as nullable, even if the Kotlin Type is non-nullable.
  * Necessary, as authorization may lead to a Node not always being provided if the user has no permission
  * to read the node.
  */

--- a/src/main/kotlin/io/github/graphglue/model/Node.kt
+++ b/src/main/kotlin/io/github/graphglue/model/Node.kt
@@ -11,6 +11,9 @@ import io.github.graphglue.data.execution.NodeQueryExecutor
 import io.github.graphglue.data.execution.NodeQueryOptions
 import io.github.graphglue.data.execution.NodeQueryResult
 import io.github.graphglue.graphql.extensions.requiredPermission
+import io.github.graphglue.model.property.BasePropertyDelegate
+import io.github.graphglue.model.property.NodePropertyDelegate
+import io.github.graphglue.model.property.NodeSetPropertyDelegate
 import org.springframework.data.annotation.Transient
 import org.springframework.data.neo4j.core.convert.ConvertWith
 import org.springframework.data.neo4j.core.schema.GeneratedValue
@@ -83,7 +86,7 @@ abstract class Node {
      * Name of property as key
      */
     @Transient
-    internal val propertyLookup: MutableMap<String, BaseProperty<*>> = mutableMapOf()
+    internal val propertyLookup: MutableMap<String, BasePropertyDelegate<*, *>> = mutableMapOf()
 
     /**
      * Creates a new node property used for many sides
@@ -92,7 +95,7 @@ abstract class Node {
      * @param T value type
      * @return a provider for the property delegate
      */
-    protected fun <T : Node> NodeSetProperty(): PropertyDelegateProvider<Node, NodeSetProperty<T>> {
+    protected fun <T : Node> NodeSetProperty(): PropertyDelegateProvider<Node, NodeSetPropertyDelegate<T>> {
         return NodeSetPropertyProvider()
     }
 
@@ -103,7 +106,7 @@ abstract class Node {
      * @param T value type
      * @return a provider for the property delegate
      */
-    protected fun <T : Node?> NodeProperty(): PropertyDelegateProvider<Node, NodeProperty<T>> {
+    protected fun <T : Node?> NodeProperty(): PropertyDelegateProvider<Node, NodePropertyDelegate<T>> {
         return NodePropertyProvider()
     }
 
@@ -153,25 +156,25 @@ abstract class Node {
      * @return the found property
      */
     @Suppress("UNCHECKED_CAST")
-    internal fun <T : Node?> getProperty(property: KProperty<*>): BaseProperty<T> {
-        return propertyLookup[property.name]!! as BaseProperty<T>
+    internal fun <T : Node?> getProperty(property: KProperty<*>): BasePropertyDelegate<T, *> {
+        return propertyLookup[property.name]!! as BasePropertyDelegate<T, *>
     }
 }
 
 /**
- * Provider for [NodeProperty]s
+ * Provider for [NodePropertyDelegate]s
  */
-private class NodePropertyProvider<T : Node?> : PropertyDelegateProvider<Node, NodeProperty<T>> {
+private class NodePropertyProvider<T : Node?> : PropertyDelegateProvider<Node, NodePropertyDelegate<T>> {
 
     /**
-     * Creates a new [NodeProperty] and registers it to the [Node.propertyLookup]
+     * Creates a new [NodePropertyDelegate] and registers it to the [Node.propertyLookup]
      *
      * @param thisRef the parent node
      * @param property the property to delegate
      * @return the generated property delegate
      */
-    override operator fun provideDelegate(thisRef: Node, property: KProperty<*>): NodeProperty<T> {
-        val nodeProperty = NodeProperty<T>(
+    override operator fun provideDelegate(thisRef: Node, property: KProperty<*>): NodePropertyDelegate<T> {
+        val nodeProperty = NodePropertyDelegate<T>(
             thisRef,
             property as KProperty1<*, *>
         )
@@ -181,23 +184,23 @@ private class NodePropertyProvider<T : Node?> : PropertyDelegateProvider<Node, N
 }
 
 /**
- * Provider for [NodeSetProperty]s
+ * Provider for [NodeSetPropertyDelegate]s
  */
-private class NodeSetPropertyProvider<T : Node> : PropertyDelegateProvider<Node, NodeSetProperty<T>> {
+private class NodeSetPropertyProvider<T : Node> : PropertyDelegateProvider<Node, NodeSetPropertyDelegate<T>> {
 
     /**
-     * Creates a new [NodeSetProperty] and registers it to the [Node.propertyLookup]
+     * Creates a new [NodeSetPropertyDelegate] and registers it to the [Node.propertyLookup]
      *
      * @param thisRef the parent node
      * @param property the property to delegate
      * @return the generated property delegate
      */
-    override operator fun provideDelegate(thisRef: Node, property: KProperty<*>): NodeSetProperty<T> {
-        val nodeSetProperty = NodeSetProperty<T>(
+    override operator fun provideDelegate(thisRef: Node, property: KProperty<*>): NodeSetPropertyDelegate<T> {
+        val nodeSetPropertyDelegate = NodeSetPropertyDelegate<T>(
             thisRef,
             property as KProperty1<*, *>
         )
-        thisRef.propertyLookup[property.name] = nodeSetProperty
-        return nodeSetProperty
+        thisRef.propertyLookup[property.name] = nodeSetPropertyDelegate
+        return nodeSetPropertyDelegate
     }
 }

--- a/src/main/kotlin/io/github/graphglue/model/NodeRelationship.kt
+++ b/src/main/kotlin/io/github/graphglue/model/NodeRelationship.kt
@@ -3,7 +3,7 @@ package io.github.graphglue.model
 
 /**
  * Used to mark manually handled node relationships
- * Must only be used on delegated properties with a delegate of type [NodeProperty] or [NodeSetProperty]
+ * Must only be used on delegated properties with a delegate of type [NodePropertyDelegate] or [NodeSetPropertyDelegate]
  *
  * @param type the associated relationship type in the database
  * @param direction the direction of the relationship

--- a/src/main/kotlin/io/github/graphglue/model/property/BasePropertyDelegate.kt
+++ b/src/main/kotlin/io/github/graphglue/model/property/BasePropertyDelegate.kt
@@ -1,4 +1,4 @@
-package io.github.graphglue.model
+package io.github.graphglue.model.property
 
 import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -9,24 +9,31 @@ import io.github.graphglue.definition.NodeDefinitionCollection
 import io.github.graphglue.data.repositories.RelationshipDiff
 import io.github.graphglue.definition.NodeDefinition
 import io.github.graphglue.graphql.extensions.getParentNodeDefinition
+import io.github.graphglue.model.Node
 import org.springframework.beans.factory.annotation.Autowired
 import java.util.*
+import kotlin.reflect.KProperty
 import kotlin.reflect.KProperty1
 
 /**
- * Base class for many and one node properties
- * Provides cache based graphql functionality, and abstract methods with allow persistence
+ * Base class for many and one node property delegates
+ * Provides cache based GraphQL functionality, and abstract methods with allow persistence
  *
  * @param parent the node which hosts this property
  * @param property the property on the class
  * @param T the type of the value [Node] (s)
+ * @param R the type of property
  */
-abstract class BaseProperty<T : Node?>(protected val parent: Node, protected val property: KProperty1<*, *>) {
+abstract class BasePropertyDelegate<T : Node?, R>(protected val parent: Node, protected val property: KProperty1<*, *>) {
 
     /**
      * Cache for database results for specific query parts
      */
     private val cache = IdentityHashMap<NodeQueryOptions, NodeQueryResult<T>>()
+
+    private val lazyLoadingDelegate = object: LazyLoadingDelegate<T, R> {
+        override suspend fun invoke() = getLoadedProperty()
+    }
 
     /**
      * Gets the result of a GraphQL query
@@ -105,9 +112,20 @@ abstract class BaseProperty<T : Node?>(protected val parent: Node, protected val
     internal abstract fun getRelatedNodesToSave(): Collection<Node>
 
     /**
-     * Marker for lazy loading delegates, necessary for property type based filter & order generation
+     * Gets the loaded property which is returned by the lazy loading delegate
      *
-     * @param R the type of the property
+     * @return the loaded property
      */
-    interface LazyLoadingDelegate<R>
+    internal abstract suspend fun getLoadedProperty(): R
+
+    /**
+     * Gets the lazy loading delegate which is used to get the value of the property
+     *
+     * @param thisRef the [Node] containing the delegated property
+     * @param property the delegated property
+     * @return the lazy loading delegate which can be used to get the property
+     */
+    operator fun getValue(thisRef: Node, property: KProperty<*>): LazyLoadingDelegate<T, R> {
+        return lazyLoadingDelegate
+    }
 }

--- a/src/main/kotlin/io/github/graphglue/model/property/LazyLoadingDelegate.kt
+++ b/src/main/kotlin/io/github/graphglue/model/property/LazyLoadingDelegate.kt
@@ -1,0 +1,16 @@
+package io.github.graphglue.model.property
+
+import io.github.graphglue.model.Node
+
+/**
+ * Delegate which can be called to get the loaded property
+ *
+ * @param T the type of Node stored in this property
+ * @param R the type of property
+ */
+interface LazyLoadingDelegate<T: Node?, R> {
+    /**
+     * Gets the loaded property
+     */
+    suspend operator fun invoke(): R
+}

--- a/website/docs/modeling.mdx
+++ b/website/docs/modeling.mdx
@@ -114,6 +114,14 @@ Kotlin `Transient` does not work and will result in strange errors, as Spring Da
 
 :::
 
+:::caution
+
+To actually get the content of a property, you have to call `get()` on the property.
+This is necessary, as lazy loading is done asynchronous, and properties cannot be marked currently with `suspend`.
+For `NodeProperty` backed properties, `set(value: T)` works accordingly.
+
+:::
+
 On save, all relationships are saved. Save cascades down added entities, but removed ones.
 Example: If the one side has initially the value `node1`, which then is replaced with `node2`, when saving, `node2` is saved (as it was "added"), while `node1` is not.
 
@@ -152,7 +160,11 @@ For more information, see [Connecting nodes: @Relationship](https://docs.spring.
         </tr>
         <tr>
             <th>Lazy loading</th>
-            <th>Only lazy loading is supported. Relations are automatically loaded when accessed. Note: when fetching data for GraphQL, the whole subtree is loaded at once using one Cypher query, preventing the n+1 problem.</th>
+            <th>
+                Only lazy loading is supported. Relations are automatically loaded when accessed. 
+                Note: when fetching data for GraphQL, the whole subtree is loaded at once using one Cypher query, preventing the n+1 problem.
+                Lazy loading is done asynchronous.
+            </th>
             <th>
                 No lazy loading is supported, all relationships are eagerly loaded, which can result in large subgraphs being loaded. To prevent this, you may use 
                 <a href="https://docs.spring.io/spring-data/neo4j/docs/current/reference/html/#projections" rel="noopener noreferer">Projections</a>

--- a/website/docs/modeling.mdx
+++ b/website/docs/modeling.mdx
@@ -116,10 +116,9 @@ Kotlin `Transient` does not work and will result in strange errors, as Spring Da
 
 :::caution
 
-To actually get the content of a property, you have to call `get()` on the property.
+To actually get the content of a property, you have to use the call operator on the property (e.g. `node.manyProperty().add(addedNode)`).
 This is necessary, as lazy loading is done asynchronous, and properties cannot be marked currently with `suspend`.
-For `NodeProperty` backed properties, `set(value: T)` works accordingly.
-
+Therefore, on invoking, the property is - if necessary - loaded from the database.
 :::
 
 On save, all relationships are saved. Save cascades down added entities, but removed ones.


### PR DESCRIPTION
- removes `reactiveTransactionManager` bean as this should be added by the user when using this library
- changes lazy loading to async and therefore removes all `runBlocking`
  - this makes it necessary to use the call operator on the properties
  - this provides the new `Node(Set)Property` which then can be used for interaction
    - `NodeProperty` provides the val `value` to get/set the node
    - `NodeSetProperty` provides `(Mutable)Set` functionality (add, remove, ...)
- refactorings
- breaking changes!