### PR TITLE
Feature/ignorable filter properties

### DIFF
--- a/src/main/kotlin/io/github/graphglue/connection/GraphglueConnectionConfiguration.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/GraphglueConnectionConfiguration.kt
@@ -7,11 +7,11 @@ import io.github.graphglue.connection.filter.definition.NodeSetPropertyFilterDef
 import io.github.graphglue.connection.filter.definition.NodeSubFilterDefinition
 import io.github.graphglue.connection.filter.definition.scalars.*
 import io.github.graphglue.definition.extensions.firstTypeArgument
-import io.github.graphglue.model.*
-import io.github.graphglue.model.property.NodePropertyDelegate
-import io.github.graphglue.model.property.NodeSetPropertyDelegate
+import io.github.graphglue.model.Node
 import io.github.graphglue.model.property.NODE_PROPERTY_TYPE
 import io.github.graphglue.model.property.NODE_SET_PROPERTY_TYPE
+import io.github.graphglue.model.property.NodePropertyDelegate
+import io.github.graphglue.model.property.NodeSetPropertyDelegate
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import kotlin.reflect.full.createType
@@ -109,14 +109,16 @@ class GraphglueConnectionConfiguration {
     @Bean
     fun nodeFilter() =
         TypeFilterDefinitionEntry(NODE_PROPERTY_TYPE) { name, property, parentNodeDefinition, subFilterGenerator ->
-            val nodeSubFilterDefinition = NodeSubFilterDefinition(
-                name,
-                "Filters for nodes where the related node match this filter",
-                property.returnType.firstTypeArgument,
-                subFilterGenerator,
-                parentNodeDefinition.getRelationshipDefinitionOfProperty(property)
-            )
-            NodePropertyFilterDefinition(nodeSubFilterDefinition)
+            parentNodeDefinition.getRelationshipDefinitionOfPropertyOrNull(property)?.let { relationshipDefinition ->
+                val nodeSubFilterDefinition = NodeSubFilterDefinition(
+                    name,
+                    "Filters for nodes where the related node match this filter",
+                    property.returnType.firstTypeArgument,
+                    subFilterGenerator,
+                    relationshipDefinition
+                )
+                NodePropertyFilterDefinition(nodeSubFilterDefinition)
+            }
         }
 
     /**
@@ -128,12 +130,14 @@ class GraphglueConnectionConfiguration {
     @Bean
     fun nodeSetFilter() =
         TypeFilterDefinitionEntry(NODE_SET_PROPERTY_TYPE) { name, property, parentNodeDefinition, subFilterGenerator ->
-            NodeSetPropertyFilterDefinition(
-                name,
-                property.returnType.firstTypeArgument,
-                subFilterGenerator,
-                parentNodeDefinition.getRelationshipDefinitionOfProperty(property)
-            )
+            parentNodeDefinition.getRelationshipDefinitionOfPropertyOrNull(property)?.let { relationshipDefinition ->
+                NodeSetPropertyFilterDefinition(
+                    name,
+                    property.returnType.firstTypeArgument,
+                    subFilterGenerator,
+                    relationshipDefinition
+                )
+            }
         }
 
 }

--- a/src/main/kotlin/io/github/graphglue/connection/filter/TypeFilterDefinitionEntry.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/TypeFilterDefinitionEntry.kt
@@ -13,10 +13,10 @@ import kotlin.reflect.KType
  * [FilterProperty]
  *
  * @param associatedType the supported type of the property
- * @param filterDefinitionFactory function to convert the property into a filter
+ * @param filterDefinitionFactory function to convert the property into a filter, if null is returned, no filter is added
  */
 data class TypeFilterDefinitionEntry(
     val associatedType: KType, val filterDefinitionFactory: (
         name: String, property: KProperty1<*, *>, parentNodeDefinition: NodeDefinition, subFilterGenerator: SubFilterGenerator
-    ) -> FilterEntryDefinition
+    ) -> FilterEntryDefinition?
 )

--- a/src/main/kotlin/io/github/graphglue/connection/filter/definition/SubFilterGenerator.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/definition/SubFilterGenerator.kt
@@ -35,10 +35,10 @@ class SubFilterGenerator(
      *
      * @param property the property to generate the filter for
      * @param parentNodeDefinition the definition of the [Node] type which contains the `property´
-     * @return the generated [FilterEntryDefinition]
-     * @throws IllegalStateException if no filter for the property type can be generated
+     * @return the generated [FilterEntryDefinition] if one was generated
+     * @throws IllegalStateException if no filter generator was found
      */
-    fun filterForProperty(property: KProperty1<*, *>, parentNodeDefinition: NodeDefinition): FilterEntryDefinition {
+    fun filterForProperty(property: KProperty1<*, *>, parentNodeDefinition: NodeDefinition): FilterEntryDefinition? {
         val type = property.returnType
         for (filter in filters) {
             if (type.isSubtypeOf(filter.associatedType)) {

--- a/src/main/kotlin/io/github/graphglue/connection/filter/definition/generateFilterDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/connection/filter/definition/generateFilterDefinition.kt
@@ -24,7 +24,7 @@ fun generateFilterDefinition(
     return subFilterGenerator.filterDefinitionCache.putAndInitIfAbsent(type, FilterDefinition(type)) {
         val nodeDefinition = subFilterGenerator.nodeDefinitionCollection.getNodeDefinition(type)
         val filterProperties = type.memberProperties.filter { it.hasAnnotation<FilterProperty>() }
-        val filterFields = filterProperties.map { subFilterGenerator.filterForProperty(it, nodeDefinition) }
+        val filterFields = filterProperties.mapNotNull { subFilterGenerator.filterForProperty(it, nodeDefinition) }
         val additionalFilterAnnotations = type.springFindRepeatableAnnotations<AdditionalFilter>()
         val additionalFilters = additionalFilterAnnotations.map {
             subFilterGenerator.additionalFilterBeans[it.beanName]!!

--- a/src/main/kotlin/io/github/graphglue/definition/NodeDefinition.kt
+++ b/src/main/kotlin/io/github/graphglue/definition/NodeDefinition.kt
@@ -130,6 +130,16 @@ class NodeDefinition(
     }
 
     /**
+     * Gets the [RelationshipDefinition] by property
+     *
+     * @param property the property to get the relation of
+     * @return the found [RelationshipDefinition] or null if none was found
+     */
+    fun getRelationshipDefinitionOfPropertyOrNull(property: KProperty1<*, *>): RelationshipDefinition? {
+        return relationshipDefinitionsByProperty[property.name]
+    }
+
+    /**
      * Generates a new CypherDSL node with the necessary labels
      */
     fun node(): org.neo4j.cypherdsl.core.Node {

--- a/website/docs/modeling.mdx
+++ b/website/docs/modeling.mdx
@@ -249,6 +249,8 @@ fun floatFilter() =
         FloatFilterDefinition(name, parentNodeDefinition.getNeo4jNameOfProperty(property))
     }
 ```
+Note that `TypeFilterDefinitionEntry` are free to not create a filter definition by returning `null` in the callback.
+This is e.g. be used for filters for `Node(Set)Property<*>` if the property has a generic type.
 
 :::info
 


### PR DESCRIPTION
- feature to allow `TypeFilterDefinitionEntry` to ignore `@FilterProperty`
- this can be used to ignore generic properties