### PR TITLE
allow non-nullable properties being initialized on other side

### DIFF
--- a/graphglue-core/src/main/kotlin/io/github/graphglue/definition/RelationshipDefinition.kt
+++ b/graphglue-core/src/main/kotlin/io/github/graphglue/definition/RelationshipDefinition.kt
@@ -148,6 +148,17 @@ abstract class RelationshipDefinition(
     }
 
     /**
+     * Validates the relationship for [Node] by calling [Node]
+     */
+    internal fun validate(
+        node: Node,
+        savingNodes: Set<Node>,
+        nodeDefinitionCollection: NodeDefinitionCollection
+    ) {
+        node.getProperty<Node>(property).validate(savingNodes, this, nodeDefinitionCollection)
+    }
+
+    /**
      * Gets related nodes to save
      *
      * @param node the node which contains the property to get the related nodes to save
@@ -158,9 +169,18 @@ abstract class RelationshipDefinition(
     }
 
     /**
+     * Gets related nodes defined by this property, but only those already loaded (therefore no lazy loading)
+     * The relationships do not have to be persisted yet
+     *
+     * @param node the node which contains the property to get the loaded related nodes
+     * @return the already loaded related nodes
+     */
+    internal fun getLoadedRelatedNodes(node: Node): Collection<Node> {
+        return node.getProperty<Node>(property).getLoadedRelatedNodes()
+    }
+
+    /**
      * Generates a field definition
-     * Important: the field has to be annotated with  [NODE_RELATIONSHIP_DIRECTIVE], otherwise data fetching does
-     * not work
      *
      * @param transformationContext used to generate GraphQL types, register data fetchers, ...
      */

--- a/graphglue-core/src/main/kotlin/io/github/graphglue/model/property/NodeSetPropertyDelegate.kt
+++ b/graphglue-core/src/main/kotlin/io/github/graphglue/model/property/NodeSetPropertyDelegate.kt
@@ -7,6 +7,8 @@ import io.github.graphglue.data.execution.NodeQueryParser
 import io.github.graphglue.data.execution.NodeQueryResult
 import io.github.graphglue.data.repositories.RelationshipDiff
 import io.github.graphglue.definition.NodeDefinition
+import io.github.graphglue.definition.NodeDefinitionCollection
+import io.github.graphglue.definition.RelationshipDefinition
 import io.github.graphglue.model.Node
 import org.neo4j.cypherdsl.core.Cypher
 import java.util.*
@@ -74,6 +76,10 @@ class NodeSetPropertyDelegate<T : Node>(
         return addedNodes
     }
 
+    override fun getLoadedRelatedNodes(): Collection<Node> {
+        return currentNodes ?: emptyList()
+    }
+
     /**
      * Ensures that this [NodeSetProperty] is loaded
      */
@@ -88,6 +94,12 @@ class NodeSetPropertyDelegate<T : Node>(
         ensureLoaded()
         return nodeSetProperty
     }
+
+    override fun validate(
+        savingNodes: Set<Node>,
+        relationshipDefinition: RelationshipDefinition,
+        nodeDefinitionCollection: NodeDefinitionCollection
+    ) {}
 
     /**
      * Node property representing the many side of a node relation.


### PR DESCRIPTION
- when having a non-nullable NodeProperty, on safe, it is ensured that a value is set
- now, this also works when the relationship is set from the other side