### PR TITLE
Feature/query cache

### DIFF
--- a/graphglue-core/src/main/kotlin/io/github/graphglue/model/property/LazyLoadingDelegate.kt
+++ b/graphglue-core/src/main/kotlin/io/github/graphglue/model/property/LazyLoadingDelegate.kt
@@ -11,6 +11,8 @@ import io.github.graphglue.model.Node
 interface LazyLoadingDelegate<T: Node?, R> {
     /**
      * Gets the loaded property
+     *
+     * @param cache used to load nodes from, if provided, not loading deleted nodes
      */
-    suspend operator fun invoke(): R
+    suspend operator fun invoke(cache: NodeCache? = null): R
 }

--- a/graphglue-core/src/main/kotlin/io/github/graphglue/model/property/NodeCache.kt
+++ b/graphglue-core/src/main/kotlin/io/github/graphglue/model/property/NodeCache.kt
@@ -1,0 +1,51 @@
+package io.github.graphglue.model.property
+
+import io.github.graphglue.model.Node
+
+/**
+ * A cache which can be used that lazy loading uses existing nodes instead of new ones
+ *
+ * @param nodes already fetched nodes
+ */
+class NodeCache(nodes: Collection<Node> = emptySet()) {
+
+    /**
+     * Internal representation of the loaded [Node]s
+     */
+    private val internalNodes = nodes.associateBy { it }.toMutableMap()
+
+    /**
+     * The loaded [Node]s, excluding deleted ones
+     */
+    val nodes: Set<Node> get() = internalNodes.keys
+
+    /**
+     * Adds a node to the cache
+     *
+     * @param node the [Node] to add
+     */
+    fun add(node: Node) {
+        internalNodes[node] = node
+    }
+
+    /**
+     * Gets the cached node equivalent to [node], otherwise puts
+     * it into the cache
+     * If already marked as deleted, or provided `null`, return `null`
+     *
+     * @param T the type of node
+     * @param node the node to get
+     * @return the node from the cache or [node]
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun <T: Node?> getOrAdd(node: T): T? {
+        return when (node) {
+            null -> null
+            else -> {
+                internalNodes.computeIfAbsent(node) {
+                    node
+                } as T
+            }
+        }
+    }
+}

--- a/graphglue-core/src/main/kotlin/io/github/graphglue/model/property/NodePropertyDelegate.kt
+++ b/graphglue-core/src/main/kotlin/io/github/graphglue/model/property/NodePropertyDelegate.kt
@@ -112,6 +112,7 @@ class NodePropertyDelegate<T : Node?>(
         if (!isLoaded) {
             val (result, _) = parent.loadNodesOfRelationship<T>(property)
             currentNode = result.nodes.firstOrNull()
+            isLoaded = true
         }
         if (cache != null && nodeCache == null) {
             nodeCache = cache

--- a/graphglue-core/src/main/kotlin/io/github/graphglue/model/property/NodePropertyDelegate.kt
+++ b/graphglue-core/src/main/kotlin/io/github/graphglue/model/property/NodePropertyDelegate.kt
@@ -105,11 +105,17 @@ class NodePropertyDelegate<T : Node?>(
 
     /**
      * Ensures that this property is loaded
+     *
+     * @param cache used to load nodes from, if provided, not loading deleted nodes
      */
-    private suspend fun ensureLoaded() {
+    private suspend fun ensureLoaded(cache: NodeCache?) {
         if (!isLoaded) {
             val (result, _) = parent.loadNodesOfRelationship<T>(property)
             currentNode = result.nodes.firstOrNull()
+        }
+        if (cache != null && nodeCache == null) {
+            nodeCache = cache
+            currentNode = cache.getOrAdd(currentNode)
         }
     }
 
@@ -127,8 +133,8 @@ class NodePropertyDelegate<T : Node?>(
         }
     }
 
-    override suspend fun getLoadedProperty(): NodeProperty {
-        ensureLoaded()
+    override suspend fun getLoadedProperty(cache: NodeCache?): NodeProperty {
+        ensureLoaded(cache)
         return nodeProperty
     }
 

--- a/graphglue-core/src/main/kotlin/io/github/graphglue/model/property/NodeSetPropertyDelegate.kt
+++ b/graphglue-core/src/main/kotlin/io/github/graphglue/model/property/NodeSetPropertyDelegate.kt
@@ -82,16 +82,22 @@ class NodeSetPropertyDelegate<T : Node>(
 
     /**
      * Ensures that this [NodeSetProperty] is loaded
+     *
+     * @param cache used to load nodes from, if provided, not loading deleted nodes
      */
-    private suspend fun ensureLoaded() {
+    private suspend fun ensureLoaded(cache: NodeCache?) {
         if (!isLoaded) {
             val (result, _) = parent.loadNodesOfRelationship<T>(property)
             currentNodes = result.nodes.toMutableSet()
         }
+        if (cache != null && nodeCache != cache) {
+            nodeCache = cache
+            currentNodes = currentNodes!!.mapNotNull(cache::getOrAdd).toMutableSet()
+        }
     }
 
-    override suspend fun getLoadedProperty(): NodeSetProperty {
-        ensureLoaded()
+    override suspend fun getLoadedProperty(cache: NodeCache?): NodeSetProperty {
+        ensureLoaded(cache)
         return nodeSetProperty
     }
 


### PR DESCRIPTION
Adds a query cache feature to all lazy loaded properties. This allows to use nodes from a cache instead of new nodes returned from the query. This can be helpfull when implementing complex algorithms, where it is inacceptable to have two nodes with the same id loaded from two different queries (mainly when performing some kind of graph updates).