### PR TITLE
fix bug with predecates due to breaking change in CypherDSL

### DIFF
--- a/graphglue-core/src/main/kotlin/io/github/graphglue/connection/filter/model/NodeRelationshipFilterEntry.kt
+++ b/graphglue-core/src/main/kotlin/io/github/graphglue/connection/filter/model/NodeRelationshipFilterEntry.kt
@@ -26,7 +26,6 @@ abstract class NodeRelationshipFilterEntry(
         val relationshipDefinition = subFilterDefinition.relationshipDefinition
         val relatedNode = Cypher.anyNode(node.requiredSymbolicName.value + "_")
         val relationship = relationshipDefinition.generateRelationship(node, relatedNode)
-        val condition = filter.generateCondition(relatedNode)
         val patternComprehension = if (permission != null) {
             val authorizationCondition =
                 subFilterDefinition.generateAuthorizationCondition(permission).generateCondition(relatedNode)
@@ -34,7 +33,9 @@ abstract class NodeRelationshipFilterEntry(
         } else {
             Cypher.listBasedOn(relationship).returning(relatedNode)
         }
-        return generatePredicate(relatedNode.requiredSymbolicName).`in`(patternComprehension).where(condition)
+        val relatedNodeAlias = Cypher.anyNode(node.requiredSymbolicName.value + "_")
+        val condition = filter.generateCondition(relatedNodeAlias)
+        return generatePredicate(relatedNodeAlias.requiredSymbolicName).`in`(patternComprehension).where(condition)
     }
 
     /**

--- a/graphglue-core/src/main/kotlin/io/github/graphglue/data/execution/NodeQueryParser.kt
+++ b/graphglue-core/src/main/kotlin/io/github/graphglue/data/execution/NodeQueryParser.kt
@@ -86,7 +86,7 @@ class NodeQueryParser(
         val idParameter = Cypher.anonParameter(parentNode.rawId)
         val rootCypherNode = parentDefinition.node().named("a_related").withProperties(mapOf("id" to idParameter))
         val additionalConditions = listOf(CypherConditionGenerator { node ->
-            Predicates.any(rootCypherNode.requiredSymbolicName).`in`(
+            Predicates.any(Cypher.name("a_related_alias")).`in`(
                 Cypher.listBasedOn(relationshipDefinition.generateRelationship(rootCypherNode, node))
                     .returning(rootCypherNode)
             ).where(Conditions.isTrue())


### PR DESCRIPTION
reusing a name for the iteration variable in a predicate causes weird behavior with newer Cypher DSL versions