### PR TITLE
fix bug that extension fields are ignored

### DIFF
--- a/graphglue-core/src/main/kotlin/io/github/graphglue/definition/NodeDefinition.kt
+++ b/graphglue-core/src/main/kotlin/io/github/graphglue/definition/NodeDefinition.kt
@@ -179,7 +179,7 @@ class NodeDefinition(
      * @return the list of found [ExtensionFieldDefinition]s
      */
     private fun generateExtensionFieldDefinitions(extensionFieldGenerators: Map<String, ExtensionFieldDefinition>): List<ExtensionFieldDefinition> {
-        val allExtensionFields = nodeType.springGetRepeatableAnnotations<ExtensionField>()
+        val allExtensionFields = nodeType.springFindRepeatableAnnotations<ExtensionField>()
         return allExtensionFields.mapNotNull {
             extensionFieldGenerators[it.beanName]
         }


### PR DESCRIPTION
if extension fields exist on more than one class in a hierarchy, extension fields on parent classes were ignored