### PR TITLE
Feature/improved subqueries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx2g
 
 # dependencies
 graphqlKotlinVersion = 8.2.1
-springBootVersion = 3.3.5
+springBootVersion = 3.4.0
 kotlinxCoroutinesReactorVersion = 1.9.0
 
 # plugins

--- a/graphglue-core/src/main/kotlin/io/github/graphglue/connection/filter/model/NodeRelationshipFilterEntry.kt
+++ b/graphglue-core/src/main/kotlin/io/github/graphglue/connection/filter/model/NodeRelationshipFilterEntry.kt
@@ -46,7 +46,7 @@ abstract class NodeRelationshipFilterEntry(
      * @param variable the name of the variable based on which the predicate should be build
      * @return the builder for the predicate
      */
-    abstract fun generatePredicate(variable: SymbolicName): Predicates.OngoingListBasedPredicateFunction
+    abstract fun generatePredicate(variable: SymbolicName): OngoingListBasedPredicateFunction
 
 }
 


### PR DESCRIPTION
- for all CALL subqueries, specify the imported variable in the subquery call
  - with a new enough CypherDSL version and a new enough configured Cypher dialect, this results in the new [variable scope clause](https://neo4j.com/docs/cypher-manual/current/subqueries/call-subquery/?utm_source=GSearch&utm_medium=PaidSearch&utm_campaign=Evergreen&utm_content=EMEA-Search-SEMCE-DSA-None-SEM-SEM-NonABM&utm_term=&utm_adgroup=DSA&gad_source=1&gclid=Cj0KCQiAgJa6BhCOARIsAMiL7V9425YtgI7NNjiTLwiD-eUAJVnf7G06qMFPk9U8aaJ8-XZ2bIFgnKYaAnl6EALw_wcB#variable-scope-clause) being used which results in a lot less warnings at runtime
- updates spring boot to 3.4.0
  - this gives us access to a new enough CypherDSL version
- we do NOT configure the Cypher dialect here, that's a decision of the application using graph-glue (thus we remain compatible with Neo4j 5.x (and maybe even 4.4.x) versions)